### PR TITLE
Different padding for pages without buttons

### DIFF
--- a/Planarian.Web/src/Configuration/NavBar/HeaderComponent.tsx
+++ b/Planarian.Web/src/Configuration/NavBar/HeaderComponent.tsx
@@ -33,7 +33,7 @@ const HeaderComponent: React.FC = () => {
       </Helmet>
       <Header
         style={{
-          paddingTop: "4px",
+          paddingTop: hasHeaderButons ? "4px" : "16px",
           paddingBottom: "4px",
           paddingLeft: "16px",
           height: "70px",


### PR DESCRIPTION
- fixed bug where pages that don't have buttons aren't centered
- this is a dirty fix, but it works