### PR TITLE
uppercase pdf still display

### DIFF
--- a/Planarian.Web/src/Modules/Files/Services/FileHelpers.ts
+++ b/Planarian.Web/src/Modules/Files/Services/FileHelpers.ts
@@ -9,7 +9,7 @@ export function isPdfFileType(fileType: string | null | undefined): boolean {
   if (!fileType) {
     return false;
   }
-  return fileType === "pdf";
+  return fileType.toLowerCase() === "pdf";
 }
 
 export const isTextFileType = (fileType: string | null | undefined) => {


### PR DESCRIPTION
- fixed bug where uppercase pdf file names were "not supported"