### PR TITLE
Feature/security

### DIFF
--- a/Planarian.Web/src/Modules/Caves/Components/CaveComponent.tsx
+++ b/Planarian.Web/src/Modules/Caves/Components/CaveComponent.tsx
@@ -81,6 +81,9 @@ const CaveComponent = ({
     isFeatureEnabled(FeatureKey.EnabledFieldCaveAlternateNames) && (
       <Descriptions.Item label="Alternative Names" key="alternative-names">
         <Row>
+          {cave?.alternateNames.length === 0 && (
+            <Col>{defaultIfEmpty(null)}</Col>
+          )}
           {cave?.alternateNames.map((name) => (
             <Col key={name}>
               <Tag>{name}</Tag>

--- a/Planarian/Planarian.Library/Extensions/String/StringExtensions.cs
+++ b/Planarian/Planarian.Library/Extensions/String/StringExtensions.cs
@@ -8,7 +8,9 @@ public static class StringExtensions
 {
     public static string[] SplitAndTrim(this string? input, char delimiter = ',')
     {
-        return input == null ? Array.Empty<string>() : input.Split(delimiter).Select(s => s.Trim()).ToArray();
+        return input == null
+            ? Array.Empty<string>()
+            : input.Split(delimiter).Where(e => !string.IsNullOrWhiteSpace(e)).Select(s => s.Trim()).ToArray();
     }
 
     public static string Quote(this string input)

--- a/Planarian/Planarian.Model/Database/Entities/LeadTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/LeadTag.cs
@@ -9,8 +9,8 @@ public class LeadTag : EntityBase
     public string TagTypeId { get; set; }
     public string LeadId { get; set; }
 
-    public TagType TagType { get; set; }
-    public Lead Lead { get; set; }
+    public TagType? TagType { get; set; }
+    public Lead? Lead { get; set; }
 }
 
 public class LeadTagConfiguration : BaseEntityTypeConfiguration<LeadTag>

--- a/Planarian/Planarian.Model/Database/Entities/Leads/Lead.cs
+++ b/Planarian/Planarian.Model/Database/Entities/Leads/Lead.cs
@@ -41,7 +41,7 @@ public class Lead : EntityBase
     [MaxLength(PropertyLength.Key)] public string Classification { get; set; }
     public DateTime? DateClosed { get; set; }
 
-    public virtual Trip Trip { get; set; } = null!;
+    public virtual Trip? Trip { get; set; } = null!;
     public virtual ICollection<LeadTag> LeadTags { get; set; } = new HashSet<LeadTag>();
 }
 

--- a/Planarian/Planarian.Model/Database/Entities/Member.cs
+++ b/Planarian/Planarian.Model/Database/Entities/Member.cs
@@ -18,7 +18,7 @@ public class Member : EntityBase
 
     public virtual Project? Project { get; set; } = null!;
     public virtual Trip? Trip { get; set; } = null!;
-    public virtual User User { get; set; } = null!;
+    public virtual User? User { get; set; } = null!;
 }
 
 public class ProjectMemberConfiguration : BaseEntityTypeConfiguration<Member>

--- a/Planarian/Planarian.Model/Database/Entities/Photo.cs
+++ b/Planarian/Planarian.Model/Database/Entities/Photo.cs
@@ -36,7 +36,7 @@ public class Photo : EntityBase
 
     [MaxLength(PropertyLength.BlobKey)] public string? BlobKey { get; set; } = null!;
 
-    public virtual Trip Trip { get; set; } = null!;
+    public virtual Trip? Trip { get; set; } = null!;
 }
 
 public class PhotoConfiguration : BaseEntityTypeConfiguration<Photo>

--- a/Planarian/Planarian.Model/Database/Entities/Projects/Project.cs
+++ b/Planarian/Planarian.Model/Database/Entities/Projects/Project.cs
@@ -11,7 +11,7 @@ public class Project : EntityBase
     [MaxLength(PropertyLength.Name)]
     public string Name { get; set; } = null!;
 
-    public virtual ICollection<Member> Members { get; set; } = null!;
+    public virtual ICollection<Member> Members { get; set; } = new HashSet<Member>();
     public virtual ICollection<Trip> Trips { get; set; } = new HashSet<Trip>();
     public virtual ICollection<TagType> CustomTagTypes { get; set; } = new HashSet<TagType>();
 }

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/AccountState.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/AccountState.cs
@@ -11,8 +11,8 @@ public class AccountState : EntityBase
     [MaxLength(PropertyLength.Id)] public string AccountId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string StateId { get; set; } = null!;
 
-    public virtual State State { get; set; } = null!;
-    public virtual Account Account { get; set; } = null!;
+    public virtual State? State { get; set; } = null!;
+    public virtual Account? Account { get; set; } = null!;
 }
 
 public class AccountStateConfiguration : IEntityTypeConfiguration<AccountState>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/AccountUser.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/AccountUser.cs
@@ -11,8 +11,8 @@ public class AccountUser : EntityBase
     [MaxLength(PropertyLength.Id)] public string AccountId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string UserId { get; set; } = null!;
 
-    public Account Account { get; set; } = null!;
-    public User User { get; set; } = null!;
+    public Account? Account { get; set; }
+    public User? User { get; set; }
 }
 
 public class AccountUserConfiguration : IEntityTypeConfiguration<AccountUser>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/ArcheologyTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/ArcheologyTag.cs
@@ -11,8 +11,8 @@ public class ArcheologyTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class ArcheologyTagConfiguration : BaseEntityTypeConfiguration<ArcheologyTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/BiologyTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/BiologyTag.cs
@@ -11,8 +11,8 @@ public class BiologyTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class BiologyTagConfiguration : BaseEntityTypeConfiguration<BiologyTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CartographerNameTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CartographerNameTag.cs
@@ -11,8 +11,8 @@ public class CartographerNameTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class CartographerNameTagConfiguration : BaseEntityTypeConfiguration<CartographerNameTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/Cave.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/Cave.cs
@@ -29,10 +29,10 @@ public class Cave : EntityBase
     public bool IsArchived { get; set; } = false;
 
 
-    public virtual Account Account { get; set; } = null!;
-    public virtual User? ReportedByUser { get; set; } = null!;
-    public virtual County County { get; set; } = null!;
-    public virtual State State { get; set; } = null!;
+    public virtual Account? Account { get; set; } = null!;
+    public virtual User? ReportedByUser { get; set; }
+    public virtual County? County { get; set; } = null!;
+    public virtual State? State { get; set; } = null!;
     public virtual ICollection<File> Files { get; set; } = new HashSet<File>();
     public virtual ICollection<Entrance> Entrances { get; set; } = new HashSet<Entrance>();
     public virtual ICollection<GeologyTag> GeologyTags { get; set; } = new HashSet<GeologyTag>();

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CaveOtherTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CaveOtherTag.cs
@@ -11,8 +11,8 @@ public class CaveOtherTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class OtherTagConfiguration : BaseEntityTypeConfiguration<CaveOtherTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CaveReportedByNameTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/CaveReportedByNameTag.cs
@@ -11,8 +11,8 @@ public class CaveReportedByNameTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class ReportedByNameTagConfiguration : BaseEntityTypeConfiguration<CaveReportedByNameTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/County.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/County.cs
@@ -12,8 +12,8 @@ public class County : EntityBaseNameId
     [MaxLength(PropertyLength.Id)] public string StateId { get; set; } = null!;
     [MaxLength(PropertyLength.SmallText)] public string DisplayId { get; set; } = null!;
 
-    public virtual Account Account { get; set; } = null!;
-    public virtual State State { get; set; } = null!;
+    public virtual Account? Account { get; set; } = null!;
+    public virtual State? State { get; set; } = null!;
     public ICollection<Cave> Caves { get; set; } = null!;
 }
 

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/Entrance.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/Entrance.cs
@@ -25,8 +25,8 @@ public class Entrance : EntityBase
     public double? PitDepthFeet { get; set; }
 
     public User? ReportedByUser { get; set; }
-    public virtual Cave Cave { get; set; } = null!;
-    public virtual TagType LocationQualityTag { get; set; } = null!;
+    public virtual Cave? Cave { get; set; } = null!;
+    public virtual TagType? LocationQualityTag { get; set; } = null!;
     public ICollection<EntranceStatusTag> EntranceStatusTags { get; set; } = new HashSet<EntranceStatusTag>();
     public ICollection<EntranceHydrologyTag> EntranceHydrologyTags { get; set; } = new HashSet<EntranceHydrologyTag>();
 

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceHydrologyTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceHydrologyTag.cs
@@ -11,8 +11,8 @@ public class EntranceHydrologyTag : EntityBase, IEntranceTag
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string EntranceId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Entrance Entrance { get; set; }
+    public TagType? TagType { get; set; }
+    public Entrance? Entrance { get; set; }
 }
 
 public class EntranceHydrologyTagConfiguration : BaseEntityTypeConfiguration<EntranceHydrologyTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceOtherTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceOtherTag.cs
@@ -11,8 +11,8 @@ public class EntranceOtherTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string EntranceId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Entrance Entrance { get; set; }
+    public TagType? TagType { get; set; }
+    public Entrance? Entrance { get; set; }
 }
 
 public class EntranceOtherTagConfiguration : BaseEntityTypeConfiguration<EntranceOtherTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceReportedByNameTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceReportedByNameTag.cs
@@ -11,8 +11,8 @@ public class EntranceReportedByNameTag : EntityBase, IEntranceTag
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string EntranceId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Entrance Entrance { get; set; }
+    public TagType? TagType { get; set; }
+    public Entrance? Entrance { get; set; }
 }
 
 public class EntranceReportedByNameTagConfiguration : BaseEntityTypeConfiguration<EntranceReportedByNameTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceStatusTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/EntranceStatusTag.cs
@@ -11,8 +11,8 @@ public class EntranceStatusTag : EntityBase, IEntranceTag
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string EntranceId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Entrance Entrance { get; set; }
+    public TagType? TagType { get; set; }
+    public Entrance? Entrance { get; set; }
 }
 
 public class EntranceStatusTagConfiguration : BaseEntityTypeConfiguration<EntranceStatusTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/FieldIndicationTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/FieldIndicationTag.cs
@@ -11,8 +11,8 @@ public class FieldIndicationTag : EntityBase, IEntranceTag
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string EntranceId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Entrance Entrance { get; set; }
+    public TagType? TagType { get; set; }
+    public Entrance? Entrance { get; set; }
 }
 
 public class FieldIndicationTagConfiguration : BaseEntityTypeConfiguration<FieldIndicationTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/File.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/File.cs
@@ -19,7 +19,7 @@ public class File : EntityBase
     public DateTime? ExpiresOn { get; set; } = null!;
     public TagType FileTypeTag { get; set; } = null!;
 
-    public virtual Cave Cave { get; set; } = null!;
+    public virtual Cave? Cave { get; set; } = null!;
     public virtual Account? Account { get; set; } = null!;
 }
 

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/File.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/File.cs
@@ -10,7 +10,7 @@ public class File : EntityBase
 {
     [MaxLength(PropertyLength.Id)] public string FileTypeTagId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string? CaveId { get; set; }
-    [MaxLength(PropertyLength.Id)] public string? AccountId { get; set; }
+    [MaxLength(PropertyLength.Id)] public string? AccountId { get; set; } // can be associated with an account but not a a cave
 
     [MaxLength(PropertyLength.Key)] public string? BlobKey { get; set; }
     [MaxLength(PropertyLength.Key)] public string? BlobContainer { get; set; }

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/GeologicAgeTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/GeologicAgeTag.cs
@@ -11,8 +11,8 @@ public class GeologicAgeTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class GeologicAgeTagConfiguration : BaseEntityTypeConfiguration<GeologicAgeTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/GeologyTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/GeologyTag.cs
@@ -11,8 +11,8 @@ public class GeologyTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class GeologyTagConfiguration : BaseEntityTypeConfiguration<GeologyTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/MapStatusTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/MapStatusTag.cs
@@ -11,8 +11,8 @@ public class MapStatusTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class MapStatusTagConfiguration : BaseEntityTypeConfiguration<MapStatusTag>

--- a/Planarian/Planarian.Model/Database/Entities/RidgeWalker/PhysiographicProvinceTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/RidgeWalker/PhysiographicProvinceTag.cs
@@ -11,8 +11,8 @@ public class PhysiographicProvinceTag : EntityBase
     [MaxLength(PropertyLength.Id)] public string TagTypeId { get; set; } = null!;
     [MaxLength(PropertyLength.Id)] public string CaveId { get; set; } = null!;
 
-    public TagType TagType { get; set; }
-    public Cave Cave { get; set; }
+    public TagType? TagType { get; set; }
+    public Cave? Cave { get; set; }
 }
 
 public class PhysiographicProvinceTagConfiguration : BaseEntityTypeConfiguration<PhysiographicProvinceTag>

--- a/Planarian/Planarian.Model/Database/Entities/TripTag.cs
+++ b/Planarian/Planarian.Model/Database/Entities/TripTag.cs
@@ -7,9 +7,10 @@ namespace Planarian.Model.Database.Entities;
 public class TripTag : EntityBase
 {
     public string TagTypeId { get; set; }
-    public TagType TagType { get; set; }
-    public Trip Trip { get; set; }
     public string TripId { get; set; }
+    
+    public TagType? TagType { get; set; }
+    public Trip? Trip { get; set; }
 }
 
 public class TripTagConfiguration : BaseEntityTypeConfiguration<TripTag>

--- a/Planarian/Planarian.Model/Generators/DataGenerator.cs
+++ b/Planarian/Planarian.Model/Generators/DataGenerator.cs
@@ -111,7 +111,6 @@ public class DataGenerator
         return new List<TagType>
         {
             new() { Id = "hM5WqDNpUZ", Name = "Yes" },
-            new() { Id = "CaHW7bd3yx", Name = "No" }
         }.Select(e => new TagType
         {
             Id = e.Id,

--- a/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
+++ b/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
@@ -189,7 +189,7 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
                 break;
             case nameof(EntranceHydrologyTag):
                 var entranceHydrologyTag = (EntranceHydrologyTag)entity.Entity;
-                var entranceHydrologyTagAccountId = entranceHydrologyTag.Entrance.Cave?.AccountId ?? await context
+                var entranceHydrologyTagAccountId = entranceHydrologyTag.Entrance?.Cave?.AccountId ?? await context
                     .EntranceHydrologyTags
                     .Where(e => e.Id == entranceHydrologyTag.Id)
                     .Select(e => e.Entrance!.Cave!.AccountId)

--- a/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
+++ b/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
@@ -110,7 +110,8 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
                 var inSameAccount = await context.AccountUsers.AnyAsync(e =>
                     e.UserId == user.Id && e.AccountId == requestUserAccountId);
 
-                var canModify = (user.Id == requestUserId && !string.IsNullOrWhiteSpace(requestUserId)) ||
+                var isResetPassword = string.IsNullOrWhiteSpace(requestUserAccountId); // should probably be more thorough in the future
+                var canModify = isResetPassword || (user.Id == requestUserId && !string.IsNullOrWhiteSpace(requestUserId)) ||
                                 inSameAccount;
                 if (!canModify)
                 {

--- a/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
+++ b/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
@@ -229,7 +229,7 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
                 break;
             case nameof(File):
                 var file = (File)entity.Entity;
-                var fileAccountId = file.Cave?.AccountId ?? await context.Files
+                var fileAccountId = file.Cave?.AccountId ?? file.AccountId ?? await context.Files
                     .Where(e => e.Id == file.Id)
                     .Select(e => e.Cave!.AccountId)
                     .FirstOrDefaultAsync();

--- a/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
+++ b/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
@@ -1,13 +1,19 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Planarian.Library.Exceptions;
 using Planarian.Model.Database;
+using Planarian.Model.Database.Entities;
+using Planarian.Model.Database.Entities.RidgeWalker;
 using Planarian.Model.Shared;
 using Planarian.Model.Shared.Base;
 using Planarian.Model.Shared.Helpers;
+using File = Planarian.Model.Database.Entities.RidgeWalker.File;
 
 namespace Planarian.Model.Interceptors;
 
-public class SaveChangesInterceptor : ISaveChangesInterceptor
+public class  SaveChangesInterceptor : ISaveChangesInterceptor
 {
     public InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
@@ -23,47 +29,251 @@ public class SaveChangesInterceptor : ISaveChangesInterceptor
     {
     }
 
-    public ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
+    public async ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData,
         InterceptionResult<int> result,
         CancellationToken cancellationToken = new())
     {
-        eventData.Context?.ChangeTracker.DetectChanges();
-        if (eventData.Context == null) return new ValueTask<InterceptionResult<int>>(result);
+        if (eventData.Context == null) return result;
 
+        eventData.Context.ChangeTracker.DetectChanges();
+
+        await SavingChangesInternalAsync(eventData);
+
+        return result;
+    }
+
+    private async Task SavingChangesInternalAsync(DbContextEventData eventData)
+    {
+        if (eventData.Context == null) return;
+        
         var context = (PlanarianDbContext)eventData.Context;
-        foreach (var entity in eventData.Context.ChangeTracker.Entries())
-            if (entity.Entity.GetType().BaseType == typeof(EntityBase) ||
-                entity.Entity.GetType().BaseType == typeof(EntityBaseNameId))
-                switch (entity.State)
+        foreach (var entityEntry in eventData.Context.ChangeTracker.Entries())
+            if (entityEntry.Entity.GetType().BaseType == typeof(EntityBase) ||
+                entityEntry.Entity.GetType().BaseType == typeof(EntityBaseNameId))
+            {
+                var entity = (EntityBase) entityEntry.Entity;
+
+                switch (entityEntry.State)
                 {
                     case EntityState.Added:
-                        ((EntityBase)entity.Entity).CreatedOn = DateTime.UtcNow;
-                        ((EntityBase)entity.Entity).CreatedByUserId = !string.IsNullOrWhiteSpace(context?.RequestUser?.Id)
-                            ? context.RequestUser.Id
-                            : null;
-                        ((EntityBase)entity.Entity).Id = !string.IsNullOrWhiteSpace(((EntityBase)entity.Entity).Id) &&
-                                                         ((EntityBase)entity.Entity).Id.Length == PropertyLength.Id
-                            ? ((EntityBase)entity.Entity).Id // use the provided id if it matches our id format
-                            : IdGenerator.Generate();
-                        break;
-                    case EntityState.Modified:
-                        ((EntityBase)entity.Entity).ModifiedOn = DateTime.UtcNow;
-                        ((EntityBase)entity.Entity).ModifiedByUserId =
+                        entity.CreatedOn = DateTime.UtcNow;
+                        entity.CreatedByUserId =
                             !string.IsNullOrWhiteSpace(context?.RequestUser?.Id)
                                 ? context.RequestUser.Id
                                 : null;
+                        entity.Id = !string.IsNullOrWhiteSpace(((EntityBase)entityEntry.Entity).Id) &&
+                                    ((EntityBase)entityEntry.Entity).Id.Length == PropertyLength.Id
+                            ? entity.Id // use the provided id if it matches our id format
+                            : IdGenerator.Generate();
+                        await Validate(context!, entityEntry, entityEntry.State);
+                        break;
+                    case EntityState.Modified:
+                        entity.ModifiedOn = DateTime.UtcNow;
+                        entity.ModifiedByUserId =
+                            !string.IsNullOrWhiteSpace(context?.RequestUser?.Id)
+                                ? context.RequestUser.Id
+                                : null;
+                        
+                        await Validate(context!, entityEntry, entityEntry.State);
                         break;
                     case EntityState.Detached:
                         break;
                     case EntityState.Unchanged:
                         break;
                     case EntityState.Deleted:
+                        await Validate(context!, entityEntry, entityEntry.State);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+            }
+    }
 
-        return new ValueTask<InterceptionResult<int>>(result);
+    private async Task Validate(PlanarianDbContext context, EntityEntry entity, EntityState entityState)
+    {
+        var name = entity.Entity.GetType().Name;
+        var requestUserAccountId = context.RequestUser.AccountId;
+        switch (name)
+        {
+            case nameof(Account):
+                var account = (Account)entity.Entity;
+                ValidateAccount(account.Id, requestUserAccountId);
+                break;
+            case nameof(AccountState):
+                var accountState = (AccountState)entity.Entity;
+                ValidateAccount(accountState.AccountId, requestUserAccountId);
+                break;
+            case nameof(User):
+                var user = (User)entity.Entity;
+                var requestUserId = context.RequestUser.Id;
+
+                var inSameAccount = await context.AccountUsers.AnyAsync(e =>
+                    e.UserId == user.Id && e.AccountId == requestUserAccountId);
+
+                var canModify = (user.Id == requestUserId && !string.IsNullOrWhiteSpace(requestUserId)) ||
+                                inSameAccount;
+                if (!canModify)
+                {
+                    throw ApiExceptionDictionary.Unauthorized(
+                        "You do not have permission to modify this entity.");
+                }
+
+                break;
+            case nameof(AccountUser):
+                var accountUser = (AccountUser)entity.Entity;
+                ValidateAccount(accountUser.AccountId, requestUserAccountId);
+                break;
+            case nameof(TagType):
+                var tagType = (TagType)entity.Entity;
+                ValidateAccount(tagType.AccountId, requestUserAccountId);
+                break;
+            case nameof(ArcheologyTag):
+                var archeologyTag = (ArcheologyTag)entity.Entity;
+
+                var archeologyTagAccountId = archeologyTag.Cave?.AccountId ?? await context.ArcheologyTags
+                    .Where(e => e.Id == archeologyTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+
+                ValidateAccount(archeologyTagAccountId, requestUserAccountId);
+                break;
+            case nameof(BiologyTag):
+                var biologyTag = (BiologyTag)entity.Entity;
+                var biologyTagAccountId = biologyTag.Cave?.AccountId ?? await context.BiologyTags
+                    .Where(e => e.Id == biologyTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(biologyTagAccountId, requestUserAccountId);
+                break;
+            case nameof(CartographerNameTag):
+                var cartographerNameTag = (CartographerNameTag)entity.Entity;
+                var cartographerNameTagAccountId = cartographerNameTag.Cave?.AccountId ?? await context
+                    .CartographerNameTags
+                    .Where(e => e.Id == cartographerNameTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(cartographerNameTagAccountId, requestUserAccountId);
+                break;
+            case nameof(Cave):
+                var cave = (Cave)entity.Entity;
+                ValidateAccount(cave.AccountId, requestUserAccountId);
+                break;
+            case nameof(CaveOtherTag):
+                var caveOtherTag = (CaveOtherTag)entity.Entity;
+                var caveOtherTagAccountId = caveOtherTag.Cave?.AccountId ?? await context.CaveOtherTags
+                    .Where(e => e.Id == caveOtherTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(caveOtherTagAccountId, requestUserAccountId);
+                break;
+            case nameof(CaveReportedByNameTag):
+                var caveReportedByNameTag = (CaveReportedByNameTag)entity.Entity;
+                var caveReportedByNameTagAccountId = caveReportedByNameTag.Cave?.AccountId ?? await context
+                    .CaveReportedByNameTags
+                    .Where(e => e.Id == caveReportedByNameTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(caveReportedByNameTagAccountId, requestUserAccountId);
+                break;
+            case nameof(County):
+                var county = (County)entity.Entity;
+                ValidateAccount(county.AccountId, requestUserAccountId);
+                break;
+            case nameof(Entrance):
+                var entrance = (Entrance)entity.Entity;
+                var entranceAccountId = entrance.Cave?.AccountId ?? await context.Entrances
+                    .Where(e => e.Id == entrance.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(entranceAccountId, requestUserAccountId);
+                break;
+            case nameof(EntranceHydrologyTag):
+                var entranceHydrologyTag = (EntranceHydrologyTag)entity.Entity;
+                var entranceHydrologyTagAccountId = entranceHydrologyTag.Entrance.Cave?.AccountId ?? await context
+                    .EntranceHydrologyTags
+                    .Where(e => e.Id == entranceHydrologyTag.Id)
+                    .Select(e => e.Entrance!.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(entranceHydrologyTagAccountId, requestUserAccountId);
+                break;
+            case nameof(EntranceReportedByNameTag):
+                var entranceReportedByNameTag = (EntranceReportedByNameTag)entity.Entity;
+                var entranceReportedByNameTagAccountId = entranceReportedByNameTag.Entrance?.Cave?.AccountId ?? await context.EntranceReportedByNameTags
+                    .Where(e => e.Id == entranceReportedByNameTag.Id)
+                    .Select(e => e.Entrance!.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+
+                ValidateAccount(entranceReportedByNameTagAccountId, requestUserAccountId);
+                break;
+            case nameof(EntranceStatusTag):
+                var entranceStatusTag = (EntranceStatusTag)entity.Entity;
+                var entranceStatusTagAccountId = entranceStatusTag.Entrance?.Cave?.AccountId ?? await context
+                    .EntranceStatusTags
+                    .Where(e => e.Id == entranceStatusTag.Id)
+                    .Select(e => e.Entrance!.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(entranceStatusTagAccountId, requestUserAccountId);
+                break;
+            case nameof(FeatureSetting):
+                var featureSetting = (FeatureSetting)entity.Entity;
+                ValidateAccount(featureSetting.AccountId, requestUserAccountId);
+                break;
+            case nameof(FieldIndicationTag):
+                var fieldIndicationTag = (FieldIndicationTag)entity.Entity;
+                var fieldIndicationTagAccountId = fieldIndicationTag.Entrance?.Cave?.AccountId ?? await context
+                    .FieldIndicationTags
+                    .Where(e => e.Id == fieldIndicationTag.Id)
+                    .Select(e => e.Entrance!.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(fieldIndicationTagAccountId, requestUserAccountId);
+                break;
+            case nameof(File):
+                var file = (File)entity.Entity;
+                var fileAccountId = file.Cave?.AccountId ?? await context.Files
+                    .Where(e => e.Id == file.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(fileAccountId, requestUserAccountId);
+                break;
+            case nameof(GeologicAgeTag):
+                var geologicAgeTag = (GeologicAgeTag)entity.Entity;
+                var geologicAgeTagAccountId = geologicAgeTag.Cave?.AccountId ?? await context.GeologicAgeTags
+                    .Where(e => e.Id == geologicAgeTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(geologicAgeTagAccountId, requestUserAccountId);
+                break;
+            case nameof(MapStatusTag):
+                var mapStatusTag = (MapStatusTag)entity.Entity;
+                var mapStatusTagAccountId = mapStatusTag.Cave?.AccountId ?? await context.MapStatusTags
+                    .Where(e => e.Id == mapStatusTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(mapStatusTagAccountId, requestUserAccountId);
+                break;
+            case nameof(PhysiographicProvinceTag):
+                var physiographicProvinceTag = (PhysiographicProvinceTag)entity.Entity;
+                var physiographicProvinceTagAccountId = physiographicProvinceTag.Cave?.AccountId ?? await context
+                    .PhysiographicProvinceTags
+                    .Where(e => e.Id == physiographicProvinceTag.Id)
+                    .Select(e => e.Cave!.AccountId)
+                    .FirstOrDefaultAsync();
+                ValidateAccount(physiographicProvinceTagAccountId, requestUserAccountId);
+                break;
+            case nameof(State):
+                throw ApiExceptionDictionary.Unauthorized("You do not have permission to modify this entity.");
+
+        }
+    }
+
+    private void ValidateAccount(string? entityAccountId, string? requestUserAccountId)
+    {
+
+        if ((!string.IsNullOrWhiteSpace(requestUserAccountId) && requestUserAccountId != entityAccountId) ||
+            !string.IsNullOrWhiteSpace(entityAccountId) && entityAccountId != requestUserAccountId)
+        {
+            throw ApiExceptionDictionary.Unauthorized("You do not have permission to modify this entity.");
+        }
     }
 
     public ValueTask<int> SavedChangesAsync(SaveChangesCompletedEventData eventData, int result,
@@ -78,3 +288,4 @@ public class SaveChangesInterceptor : ISaveChangesInterceptor
         return Task.CompletedTask;
     }
 }
+

--- a/Planarian/Planarian/Modules/Account/Repositories/AccountRepository.cs
+++ b/Planarian/Planarian/Modules/Account/Repositories/AccountRepository.cs
@@ -1,11 +1,14 @@
+using System.Linq.Expressions;
 using LinqToDB;
 using LinqToDB.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Planarian.Model.Database;
+using Planarian.Model.Database.Entities;
 using Planarian.Model.Database.Entities.RidgeWalker;
 using Planarian.Model.Shared;
 using Planarian.Modules.Account.Model;
 using Planarian.Shared.Base;
+using File = Planarian.Model.Database.Entities.RidgeWalker.File;
 
 namespace Planarian.Modules.Account.Repositories;
 
@@ -172,103 +175,65 @@ public class AccountRepository : RepositoryBase
         {
             if (tagTypeId == destinationTagTypeId) continue; // skip if it's the same as destination
 
-            // Update the TagTypeId in each tag table
+            #region Project Tags
 
-            #region Trip Data
-
-            await DbContext.TripTags
-                .Where(e => e.TagTypeId == tagTypeId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.LeadTags
-                .Where(e => e.TagTypeId == tagTypeId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
+            // await MergeTagsWithConflictHandling<LeadTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId);
+            // await MergeTagsWithConflictHandling<TripTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId);
 
             #endregion
 
-            await DbContext.ArcheologyTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
+            #region Cave Tags
 
-            await DbContext.BiologyTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.CaveOtherTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.EntranceHydrologyTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Entrance.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.EntranceStatusTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Entrance.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.FieldIndicationTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Entrance.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.Files
-                .Where(e => e.FileTypeTagId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(ee => ee.FileTypeTagId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.GeologicAgeTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.GeologyTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.Entrances
-                .Where(e => e.LocationQualityTagId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.LocationQualityTagId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.MapStatusTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            #region People Tags
-
-            // TODO: Error when merging someone who already has the same tag type for CartographerNameTag
-            await DbContext.CartographerNameTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
-            await DbContext.EntranceReportedByNameTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Entrance.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-            await DbContext.CaveReportedByNameTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
-
+            await MergeTagsWithConflictHandling<ArcheologyTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<BiologyTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<CartographerNameTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<CaveOtherTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<CaveReportedByNameTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<File>(tagTypeId, destinationTagTypeId, e => e.FileTypeTagId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<GeologicAgeTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<GeologyTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<MapStatusTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<PhysiographicProvinceTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);
+            
             #endregion
 
-            await DbContext.PhysiographicProvinceTags
-                .Where(e => e.TagTypeId == tagTypeId && e.Cave.AccountId == RequestUser.AccountId)
-                .Set(e => e.TagTypeId, destinationTagTypeId)
-                .UpdateAsync();
+            #region Entrance Tags
+
+
+            await MergeTagsWithConflictHandling<Entrance>(tagTypeId, destinationTagTypeId, e => e.LocationQualityTagId, e => e.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<EntranceHydrologyTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e => e.Entrance!.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<EntranceReportedByNameTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e => e.Entrance!.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<EntranceStatusTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e => e.Entrance!.Cave!.AccountId);
+            await MergeTagsWithConflictHandling<FieldIndicationTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e => e.Entrance!.Cave!.AccountId);
+
+            #endregion
         }
 
         await DbContext.SaveChangesAsync();
+    }
+
+    private async Task MergeTagsWithConflictHandling<T>(
+        string sourceTagTypeId,
+        string destinationTagTypeId,
+        Expression<Func<T, string>> tagTypeSelector,
+        Expression<Func<T, string>> accountIdSelector) where T : class
+    {
+        // Remove any existing tags of the destination type for the same CaveId
+        var existingTags = DbContext.Set<T>()
+            .Where(tagTypeSelector.Compose(s => s == destinationTagTypeId))
+            .Where(accountIdSelector.Compose(a => a == RequestUser.AccountId));
+
+        DbContext.Set<T>().RemoveRange(existingTags);
+        await DbContext.SaveChangesAsync();
+
+        var tags = DbContext.Set<T>()
+            .Where(tagTypeSelector.Compose(s => s == sourceTagTypeId))
+            .Where(accountIdSelector.Compose(a => a == RequestUser.AccountId));
+
+
+        await tags
+            .Set(tagTypeSelector, destinationTagTypeId)
+            .UpdateAsync();
     }
 
     private void UpdateTagTypeId<T>(ICollection<T> tags, string destinationTagTypeId) where T : class
@@ -379,5 +344,16 @@ public class AccountRepository : RepositoryBase
         return await DbContext.AccountStates
             .Where(e => e.AccountId == accountId && e.StateId == deletedStateId)
             .FirstOrDefaultAsyncEF();
+    }
+}
+
+public static class ExpressionExtensions
+{
+    public static Expression<Func<T, bool>> Compose<T>(this Expression<Func<T, string>> selector,
+        Expression<Func<string, bool>> condition)
+    {
+        var parameter = selector.Parameters[0];
+        var body = Expression.Invoke(condition, selector.Body);
+        return Expression.Lambda<Func<T, bool>>(body, parameter);
     }
 }

--- a/Planarian/Planarian/Modules/Account/Repositories/AccountRepository.cs
+++ b/Planarian/Planarian/Modules/Account/Repositories/AccountRepository.cs
@@ -175,13 +175,6 @@ public class AccountRepository : RepositoryBase
         {
             if (tagTypeId == destinationTagTypeId) continue; // skip if it's the same as destination
 
-            #region Project Tags
-
-            // await MergeTagsWithConflictHandling<LeadTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId);
-            // await MergeTagsWithConflictHandling<TripTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId);
-
-            #endregion
-
             #region Cave Tags
 
             await MergeTagsWithConflictHandling<ArcheologyTag>(tagTypeId, destinationTagTypeId, e => e.TagTypeId, e=>e.Cave!.AccountId);

--- a/Planarian/Planarian/Modules/Account/Services/AccountService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/AccountService.cs
@@ -220,7 +220,7 @@ public class AccountService : ServiceBase<AccountRepository>
 
         if (entity == null) throw ApiExceptionDictionary.NotFound("County Id");
 
-        var isDuplicateCountyCode =
+        var isDuplicateCountyCode = isNewCounty &&
             await Repository.IsDuplicateCountyCode(county.CountyDisplayId, stateId, cancellationToken);
 
         if (isDuplicateCountyCode)

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -935,7 +935,6 @@ public class ImportService : ServiceBase
         
         // Determine new tags that don't already exist in the system
         var newTags = tags.Where(gt => allTags.All(ag => ag.Name != gt.Name)).ToList();
-        var newTagsNames = newTags.Select(e => e.Name).ToList();
         foreach (var newTag in newTags)
         {
             if (newTag.Name.Length > PropertyLength.Name)

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -156,7 +156,7 @@ public class ImportService : ServiceBase
 
             var allMapStatusTags = await CreateAndProcessCaveTags(caveRecords,
                 await _tagRepository.GetTags(TagTypeKeyConstant.MapStatus),
-                TagTypeKeyConstant.Geology, e => e.Geology?.SplitAndTrim(), signalRGroup, cancellationToken);
+                TagTypeKeyConstant.MapStatus, e => e.MapStatuses?.SplitAndTrim(), signalRGroup, cancellationToken);
 
             var allPhysiographicProvincesTags = await CreateAndProcessCaveTags(caveRecords,
                 await _tagRepository.GetTags(TagTypeKeyConstant.PhysiographicProvince),
@@ -930,11 +930,12 @@ public class ImportService : ServiceBase
                 Id = IdGenerator.Generate(),
                 Name = e ?? throw ApiExceptionDictionary.NullValue(nameof(TagType.Name))
             })
+            .OrderBy(e=>e.Name)
             .ToList();
-
+        
         // Determine new tags that don't already exist in the system
         var newTags = tags.Where(gt => allTags.All(ag => ag.Name != gt.Name)).ToList();
-
+        var newTagsNames = newTags.Select(e => e.Name).ToList();
         foreach (var newTag in newTags)
         {
             if (newTag.Name.Length > PropertyLength.Name)

--- a/Planarian/Planarian/Modules/App/Repositories/AppRepository.cs
+++ b/Planarian/Planarian/Modules/App/Repositories/AppRepository.cs
@@ -16,8 +16,8 @@ public class AppRepository : RepositoryBase
     {
         return await DbContext.AccountUsers
             .Where(e => e.UserId == RequestUser.Id)
-            .OrderByDescending(e => e.Account.Name)
-            .Select(e => new SelectListItem<string> { Display = e.Account.Name, Value = e.AccountId })
+            .OrderByDescending(e => e.Account!.Name)
+            .Select(e => new SelectListItem<string> { Display = e.Account!.Name, Value = e.AccountId })
             .ToListAsync();
     }
 }

--- a/Planarian/Planarian/Modules/Authentication/Repositories/AuthenticationRepository.cs
+++ b/Planarian/Planarian/Modules/Authentication/Repositories/AuthenticationRepository.cs
@@ -17,7 +17,7 @@ public class AuthenticationRepository : RepositoryBase
     {
         return await DbContext.AccountUsers
             .Where(e => e.UserId == userId)
-            .OrderByDescending(e => e.Account.Name)
+            .OrderByDescending(e => e.Account!.Name)
             .Select(e => e.AccountId)
             .ToListAsync();
     }

--- a/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
+++ b/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
@@ -483,7 +483,7 @@ public class CaveRepository : RepositoryBase
             .Include(e => e.EntranceOtherTags)
             .Include(e => e.EntranceHydrologyTags)
             .Include(e => e.EntranceReportedByNameTags)
-            .Where(e => e.Id == id && e.Cave.AccountId == RequestUser.AccountId).FirstOrDefaultAsync();
+            .Where(e => e.Id == id && e.Cave!.AccountId == RequestUser.AccountId).FirstOrDefaultAsync();
     }
 
     public async Task<Cave?> GetAsync(string? id)
@@ -524,9 +524,10 @@ public class CaveRepository : RepositoryBase
         CancellationToken cancellationToken)
     {
         var result = await DbContext.Caves
-            .Where(e => e.County.DisplayId == countyDisplayId && e.CountyNumber == countyNumber)
+            .Where(e=>e.AccountId == RequestUser.AccountId)
+            .Where(e => e.County!.DisplayId == countyDisplayId && e.CountyNumber == countyNumber)
             .Select(e => new GetCaveForFileImportByCountyCodeNumberResult(e.Id,
-                $"{e.County.DisplayId}{e.Account.CountyIdDelimiter}{e.CountyNumber} {e.Name}"))
+                $"{e.County!.DisplayId}{e.Account!.CountyIdDelimiter}{e.CountyNumber} {e.Name}"))
             .FirstOrDefaultAsync(cancellationToken: cancellationToken);
 
         return result;

--- a/Planarian/Planarian/Modules/Files/Repositories/FileRepository.cs
+++ b/Planarian/Planarian/Modules/Files/Repositories/FileRepository.cs
@@ -15,7 +15,7 @@ public class FileRepository : RepositoryBase
 
     public async Task<File?> GetCaveFileByBlobKey(string blobKey)
     {
-        return await DbContext.Files.Where(e => e.BlobKey == blobKey && e.Cave.AccountId == RequestUser.AccountId)
+        return await DbContext.Files.Where(e => e.BlobKey == blobKey && e.Cave!.AccountId == RequestUser.AccountId)
             .FirstOrDefaultAsync();
     }
 

--- a/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
+++ b/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
@@ -94,7 +94,7 @@ public class TemporaryEntranceRepository : RepositoryBase
 
 
         var deleteResult = await db.GetTable<TemporaryEntrance>()
-            .TableName(_temporaryEntranceTableName) // Use dynamic table name
+            .TableName(_temporaryEntranceTableName)
             .Where(e => e.CaveId == null).DeleteAsync();
 
         return (unassociatedEntrances, associatedEntrances);
@@ -137,7 +137,6 @@ public class TemporaryEntranceRepository : RepositoryBase
 
     public async Task MigrateTemporaryEntrancesAsync()
     {
-        // TODO Reported by name
         var command = $@"
         INSERT INTO {nameof(DbContext.Entrances).Quote()} (
             {nameof(Entrance.Id).Quote()},
@@ -175,8 +174,7 @@ public class TemporaryEntranceRepository : RepositoryBase
             {nameof(TemporaryEntrance.CreatedOn).Quote()},
             {nameof(TemporaryEntrance.ModifiedOn).Quote()}
         FROM {_temporaryEntranceTableName.Quote()}";
-
-
+        
         await DbContext.Database.ExecuteSqlRawAsync(command);
     }
 

--- a/Planarian/Planarian/Modules/Leads/Repositories/LeadRepository.cs
+++ b/Planarian/Planarian/Modules/Leads/Repositories/LeadRepository.cs
@@ -15,7 +15,7 @@ public class LeadRepository : RepositoryBase
     public async Task<LeadVm?> GetLead(string leadId)
     {
         return await DbContext.Leads.Where(e =>
-                e.Id == leadId && e.Trip.Project.Members.Any(ee => ee.UserId == RequestUser.Id))
+                e.Id == leadId && e.Trip!.Project.Members.Any(ee => ee.UserId == RequestUser.Id))
             .Select(e => new LeadVm(e))
             .FirstOrDefaultAsync();
     }
@@ -23,7 +23,7 @@ public class LeadRepository : RepositoryBase
     public async Task<Lead?> Get(string leadId)
     {
         return await DbContext.Leads.Where(e =>
-                e.Id == leadId && e.Trip.Project.Members.Any(ee => ee.UserId == RequestUser.Id))
+                e.Id == leadId && e.Trip!.Project.Members.Any(ee => ee.UserId == RequestUser.Id))
             .FirstOrDefaultAsync();
     }
 }

--- a/Planarian/Planarian/Modules/Map/Controllers/MapRepository.cs
+++ b/Planarian/Planarian/Modules/Map/Controllers/MapRepository.cs
@@ -30,8 +30,8 @@ public class MapRepository : RepositoryBase
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
 
             return await DbContext.Entrances
-                .Where(e => e.Cave.AccountId == RequestUser.AccountId)
-                .Select(e => new { e.Location, e.Cave.Name, e.Cave.Id })
+                .Where(e => e.Cave!.AccountId == RequestUser.AccountId)
+                .Select(e => new { e.Location, e.Cave!.Name, e.Cave.Id })
                 .ToListAsync(cancellationToken: cancellationToken);
         });
 

--- a/Planarian/Planarian/Modules/Photos/Repositories/PhotoRepository.cs
+++ b/Planarian/Planarian/Modules/Photos/Repositories/PhotoRepository.cs
@@ -15,6 +15,6 @@ public class PhotoRepository : RepositoryBase
     public async Task<Photo?> GetPhoto(string tripPhotoId)
     {
         return await DbContext.Photos.FirstOrDefaultAsync(e =>
-            e.Id == tripPhotoId && e.Trip.Project.Members.Any(ee => ee.UserId == RequestUser.Id));
+            e.Id == tripPhotoId && e.Trip!.Project.Members.Any(ee => ee.UserId == RequestUser.Id));
     }
 }

--- a/Planarian/Planarian/Modules/Query/Extensions/QueryableExtensions.cs
+++ b/Planarian/Planarian/Modules/Query/Extensions/QueryableExtensions.cs
@@ -6,7 +6,7 @@ using Planarian.Modules.Query.Models;
 
 namespace Planarian.Modules.Query.Extensions;
 
-public static class QueryableExtensions
+public static class  QueryableExtensions
 {
     // public static IQueryable<T> QueryFilter<T>(this IQueryable<T> source, IEnumerable<QueryCondition> conditions)
     // {

--- a/Planarian/Planarian/Modules/Settings/Repositories/SettingsRepository.cs
+++ b/Planarian/Planarian/Modules/Settings/Repositories/SettingsRepository.cs
@@ -15,7 +15,9 @@ public class SettingsRepository : RepositoryBase
 
     public async Task<string> GetTagTypeName(string tagTypeId)
     {
-        return await DbContext.TagTypes.Where(e => e.Id == tagTypeId).Select(e => e.Name).FirstAsync();
+        return await DbContext.TagTypes
+            .Where(e => e.Id == tagTypeId && (e.AccountId == RequestUser.AccountId || e.IsDefault)).Select(e => e.Name)
+            .FirstAsync();
     }
 
     public async Task<NameProfilePhotoVm> GetUserNameProfilePhoto(string userId)

--- a/Planarian/Planarian/Modules/Tags/Repositories/TagRepository.cs
+++ b/Planarian/Planarian/Modules/Tags/Repositories/TagRepository.cs
@@ -81,6 +81,6 @@ public class TagRepository : RepositoryBase
     {
         return DbContext.TagTypes
             .Where(e => e.Key == key &&
-                        (e.AccountId == RequestUser.AccountId || string.IsNullOrWhiteSpace(e.AccountId) && e.IsDefault));
+                        (e.AccountId == RequestUser.AccountId || e.IsDefault));
     }
 }

--- a/Templates/Emails/GenericEmailTemplate.mjml
+++ b/Templates/Emails/GenericEmailTemplate.mjml
@@ -1,35 +1,40 @@
 <mjml>
+  <mj-head>
+    <mj-style inline="inline">
+      .body-container {
+        background-color: #F7F7F7;
+        padding: 20px;
+      }
+    </mj-style>
+  </mj-head>
   <mj-body>
     <mj-section>
       <mj-column>
-
-        <mj-text font-size="24px" color="#F45E43" font-family="helvetica">
-          {{header}}
-        </mj-text>
-
-        <mj-raw>
-          {{#if messages}}
-            {{#each messages}}
-        </mj-raw>
-        <mj-text font-size="16px" color="#F45E43" font-family="helvetica">
-          {{this}}
-        </mj-text>
-        <mj-raw>
-
-          {{/each}}
-          {{/if}}
-        </mj-raw>
-        <mj-raw>
-          {{#if buttonText}}
-        </mj-raw>
-        <mj-button background-color="#F63A4D" href="{{buttonUrl}}">
-          {{buttonText}}
-        </mj-button>
-        <mj-raw>
-
-          {{/if}}
-        </mj-raw>
+        <mj-image width="150px" src="https://saplanarian.blob.core.windows.net/public/planarianLogo.png"></mj-image>
+        <mj-text align="center" font-size="20px">Planarian</mj-text>
       </mj-column>
     </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="16px">{{header}}</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-raw>
+          {{#each messages}}
+        </mj-raw>
+        <mj-text>{{this}}</mj-text>
+        <mj-raw>{{/each}}</mj-raw>
+      </mj-column>
+    </mj-section>
+    <mj-raw>{{#if buttonText}}</mj-raw>
+    <mj-section>
+      <mj-column>
+        <mj-button background-color="#1990ff" color="#FFFFFF" padding="10px 25px" border-radius="5px" href="{{buttonUrl}}">{{buttonText}}</mj-button>
+
+      </mj-column>
+    </mj-section>
+    <mj-raw>{{/if}}</mj-raw>
   </mj-body>
 </mjml>


### PR DESCRIPTION
- block edits on entities not related to the accountId on the request user
- fixed security bug where merging default tag types merged everyones tags
- fixed merging tags when the tag already existed on the entity
- fixed bug that didn't allow renaming counties because it treated it as a duplicate county code
- updated email template
- fixed bug that duplicated some tag names during import