### PR TITLE
Mobile UI Improvements

### DIFF
--- a/Planarian.Web/public/index.html
+++ b/Planarian.Web/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <link href='https://unpkg.com/maplibre-gl@1.15.3/dist/maplibre-gl.css' rel='stylesheet' />
     <link href="%PUBLIC_URL%/favicon.ico" rel="icon"/>
-    <meta content="width=device-width, initial-scale=1" name="viewport"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta content="#000000" name="theme-color"/>
     <meta
             content="Web site created using create-react-app"

--- a/Planarian.Web/src/Modules/Caves/Components/CaveComponent.tsx
+++ b/Planarian.Web/src/Modules/Caves/Components/CaveComponent.tsx
@@ -7,6 +7,7 @@ import {
   Col,
   Collapse,
   Descriptions,
+  Grid,
   Row,
   Space,
   Tag,
@@ -73,6 +74,9 @@ const CaveComponent = ({
   const { isFeatureEnabled } = useFeatureEnabled();
 
   const [showMap, setShowMap] = useState(true);
+
+  const screens = Grid.useBreakpoint();
+  const descriptionLayout = screens.md ? "horizontal" : "vertical";
 
   // have to do this because of a weird bug with the Descriptions component where wrappers don't work (elements still get displayed)
   const descriptionItems = [
@@ -274,7 +278,9 @@ const CaveComponent = ({
         loading={isLoading}
       >
         <PlanarianDividerComponent title="Information" />
-        <Descriptions bordered>{descriptionItems}</Descriptions>
+        <Descriptions layout={descriptionLayout} bordered>
+          {descriptionItems}
+        </Descriptions>
         {cave?.entrances && cave?.entrances.length > 0 && (
           <>
             <PlanarianDividerComponent title="Entrances" />
@@ -300,7 +306,7 @@ const CaveComponent = ({
                   }
                   key={index}
                 >
-                  <Descriptions bordered>
+                  <Descriptions bordered layout={descriptionLayout}>
                     {entranceItems(entrance)}
                   </Descriptions>
                 </Panel>

--- a/Planarian.Web/src/Modules/Caves/Pages/CavePage.tsx
+++ b/Planarian.Web/src/Modules/Caves/Pages/CavePage.tsx
@@ -18,7 +18,12 @@ const CavePage = () => {
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const { setHeaderTitle, setHeaderButtons } = useContext(AppContext);
+  const {
+    setHeaderTitle,
+    setHeaderButtons,
+    defaultContentStyle,
+    setContentStyle,
+  } = useContext(AppContext);
   const { caveId } = useParams();
 
   const [hasEditPermission, setHasEditPermission] = useState<boolean>(false);
@@ -77,6 +82,12 @@ const CavePage = () => {
       setIsLoading(false);
     };
     getCave();
+
+    setContentStyle({});
+
+    return () => {
+      setContentStyle(defaultContentStyle);
+    };
   }, []);
 
   return (

--- a/Planarian.Web/src/Modules/Search/Services/QueryBuilder.ts
+++ b/Planarian.Web/src/Modules/Search/Services/QueryBuilder.ts
@@ -54,7 +54,7 @@ class QueryBuilder<T extends object> {
     this.conditions = filerQuery.conditions ?? [];
 
     this.currentPage = filerQuery.pageNumber ?? 1;
-    this.pageSize = filerQuery.pageSize ?? 8;
+    this.pageSize = filerQuery.pageSize ?? 16;
   }
 
   changeOperators(

--- a/Planarian.Web/src/index.css
+++ b/Planarian.Web/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+html, body {
+  overscroll-behavior: none;
+}


### PR DESCRIPTION
- prevent zooming on mobile
- cave/entrance information uses a vertical header when the screen gets small enough
- removed padding from cave page
- prevent refresh via pulling down from top to prevent accidental refresh on map page