### PR TITLE
Npgsql.PostgresException "NarrativeSearchVector"

### DIFF
--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using CsvHelper;
 using CsvHelper.Configuration;
+using EFCore.BulkExtensions;
 using LinqToDB.Tools;
 using Microsoft.EntityFrameworkCore.Storage;
 using Planarian.Library.Constants;
@@ -604,8 +605,14 @@ public class ImportService : ServiceBase
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Inserting caves. This may take a while...");
+
+            var config = new BulkConfig
+            {
+                // TODO: exclude the generated tsvector column. I feel like this should auto-exclude but it isn't...
+                PropertiesToExclude = new List<string> { nameof(Cave.NarrativeSearchVector) }
+            };
             await _repository.BulkInsertAsync(caves, onBatchProcessed: OnBatchProcessed,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken, bulkConfig:config);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting caves!");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting geology tags.");


### PR DESCRIPTION
fixed - Npgsql.PostgresException (0x80004005): 42P10: column "NarrativeSearchVector" is a generated column that caused the import to not work.