### PR TITLE
Request User Speed Improvements

### DIFF
--- a/Planarian/Planarian.Model/Shared/RequestUser.cs
+++ b/Planarian/Planarian.Model/Shared/RequestUser.cs
@@ -35,7 +35,7 @@ public class RequestUser
                 e.FirstName,
                 e.LastName,
                 e.LastActiveOn,
-                AccountIds = e.AccountUsers.Select(accountUser => accountUser.AccountId).ToList()
+                IsValidAccountId = e.AccountUsers.Any(au => au.AccountId == accountId)
             })
             .FirstOrDefaultAsync();
 
@@ -45,7 +45,7 @@ public class RequestUser
             return;
         }
 
-        var isValidAccountId = user.AccountIds.Contains(accountId);
+        var isValidAccountId = user.IsValidAccountId;
 
         if (!isValidAccountId && !string.IsNullOrWhiteSpace(accountId))
         {

--- a/Planarian/Planarian.Model/Shared/RequestUser.cs
+++ b/Planarian/Planarian.Model/Shared/RequestUser.cs
@@ -8,6 +8,7 @@ namespace Planarian.Model.Shared;
 
 public class RequestUser
 {
+    private static readonly TimeSpan LastActiveOnUpdateInterval = TimeSpan.FromMinutes(10);
     private readonly PlanarianDbContext _dbContext;
 
     public RequestUser(PlanarianDbContext dbContext)
@@ -25,14 +26,26 @@ public class RequestUser
 
     public async Task Initialize(string? accountId, string? userId)
     {
-        var user = await _dbContext.Users.Include(e => e.AccountUsers).FirstOrDefaultAsync(e => e.Id == userId);
+        var user = await _dbContext.Users
+            .AsNoTracking()
+            .Where(e => e.Id == userId)
+            .Select(e => new
+            {
+                e.Id,
+                e.FirstName,
+                e.LastName,
+                e.LastActiveOn,
+                AccountIds = e.AccountUsers.Select(accountUser => accountUser.AccountId).ToList()
+            })
+            .FirstOrDefaultAsync();
+
         if (user == null)
         {
             IsAuthenticated = false;
             return;
         }
 
-        var isValidAccountId = user.AccountUsers.Select(e => e.AccountId).Contains(accountId);
+        var isValidAccountId = user.AccountIds.Contains(accountId);
 
         if (!isValidAccountId && !string.IsNullOrWhiteSpace(accountId))
         {
@@ -49,10 +62,18 @@ public class RequestUser
         {
             AccountId = accountId;
             UserGroupPrefix = $"{userId}-{AccountId}";
-        } 
-        
-        user.LastActiveOn = DateTime.UtcNow;
-        await _dbContext.SaveChangesAsync();
+        }
+
+        var utcNow = DateTime.UtcNow;
+        var lastActiveThreshold = utcNow.Subtract(LastActiveOnUpdateInterval);
+
+        if (user.LastActiveOn == null || user.LastActiveOn < lastActiveThreshold)
+        {
+            await _dbContext.Users
+                .Where(e => e.Id == user.Id && (e.LastActiveOn == null || e.LastActiveOn < lastActiveThreshold))
+                .ExecuteUpdateAsync(setters =>
+                    setters.SetProperty(e => e.LastActiveOn, utcNow));
+        }
 
 
     }


### PR DESCRIPTION
- [x] Switch user initialization query to `AsNoTracking` with a narrow projection
- [x] Update `LastActiveOn` only when stale (older than 10 minutes)
- [x] Replace `AccountIds` list projection with `IsValidAccountId = e.AccountUsers.Any(au => au.AccountId == accountId)` to avoid materializing the full ID list for a single existence check