### PR TITLE
TCS Import

### DIFF
--- a/Import/Import/.idea/.idea.Import/.idea/encodings.xml
+++ b/Import/Import/.idea/.idea.Import/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/Import/Import/Tcs/CaveRecordMap.cs
+++ b/Import/Import/Tcs/CaveRecordMap.cs
@@ -10,21 +10,21 @@ public sealed class CaveRecordMap : ClassMap<CaveRecord>
         Map(m => m.CaveName).Name("name");
         Map(m => m.Latitude).Name("latitude");
         Map(m => m.Longitude).Name("longitude");
-        Map(m => m.LengthFt).Name("length");
-        Map(m => m.DepthFt).Name("depth");
-        Map(m => m.PitDepthFt).Name("pdep");
-        Map(m => m.NumberOfPits).Name("ps");
-        Map(m => m.CountyName).Name("co_name");
-        Map(m => m.TopographicName).Name("topo_name");
-        Map(m => m.ElevationFt).Name("elev");
+        Map(m => m.LengthFt).Name("length").TypeConverter<IntFromTextConverter>();
+        Map(m => m.DepthFt).Name("depth", "vertical extent").TypeConverter<IntFromTextConverter>();
+        Map(m => m.PitDepthFt).Name("pdep", "pit depth").TypeConverter<IntFromTextConverter>();
+        Map(m => m.NumberOfPits).Name("ps", "pits").TypeConverter<IntFromTextConverter>();
+        Map(m => m.CountyName).Name("co_name", "county");
+        Map(m => m.TopographicName).Name("topo_name", "topo");
+        Map(m => m.ElevationFt).Name("elev").TypeConverter<IntFromTextConverter>();
         Map(m => m.Ownership).Name("ownership");
-        Map(m => m.RequiredGear).Name("gear");
-        Map(m => m.EntranceType).Name("ent_type");
+        Map(m => m.RequiredGear).Name("gear", "equipment");
+        Map(m => m.EntranceType).Name("ent_type", "entry");
         Map(m => m.FieldIndication).Name("field_indi");
-        Map(m => m.MapStatus).Name("map_status");
+        Map(m => m.MapStatus).Name("map_status", "map status");
         Map(m => m.CaveGeology).Name("geology");
         Map(m => m.GeologicalAge).Name("geo_age");
         Map(m => m.PhysiographicProvince).Name("phys_prov");
-        Map(m => m.Narrative).Name("narrative");
+        Map(m => m.Narrative).Name("narrative", "desc");
     }
 }

--- a/Import/Import/Tcs/IntFromTextConverter.cs
+++ b/Import/Import/Tcs/IntFromTextConverter.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+
+namespace Tcs;
+
+public sealed partial class IntFromTextConverter : DefaultTypeConverter
+{
+    public override object ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
+        {
+            return parsedValue;
+        }
+
+        var match = FirstIntegerRegex().Match(text);
+        if (match.Success && int.TryParse(match.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedValue))
+        {
+            return parsedValue;
+        }
+
+        return 0;
+    }
+
+    [GeneratedRegex(@"-?\d+")]
+    private static partial Regex FirstIntegerRegex();
+}

--- a/Import/Import/Tcs/Program.cs
+++ b/Import/Import/Tcs/Program.cs
@@ -6,6 +6,94 @@ using Tcs;
 
 public partial class Program
 {
+    private static readonly Dictionary<string, string> GeologyCanonicalNames =
+        new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["Monteagle Ls"] = "Monteagle Limestone",
+            ["Monteagle"] = "Monteagle Limestone",
+            ["Hartselle"] = "Hartselle Formation",
+            ["Bangor"] = "Bangor Limestone",
+            ["Warsaw Ls"] = "Warsaw Limestone",
+            ["St Louis Ls"] = "St Louis Limestone",
+            ["St Louis"] = "St Louis Limestone",
+            ["Pennington"] = "Pennington Formation",
+            ["Bigby-Canon Limestone"] = "Bigby-Cannon Limestone",
+            ["Bigby-Cannon Ls"] = "Bigby-Cannon Limestone",
+            ["Leipers-Catheys Fm"] = "Leipers-Catheys Formation",
+            ["Leipers-Catheys"] = "Leipers-Catheys Formation",
+            ["Chepultepec Do"] = "Chepultepec Dolomite",
+            ["Chepultepec"] = "Chepultepec Dolomite",
+            ["Blackford Fm"] = "Blackford Formation",
+            ["Eidson Member of Lincolnshire Fm"] = "Eidson Member of Lincolnshire Formation",
+            ["Hardin SS"] = "Hardin Sandstone",
+            ["Lincoinshire Formation"] = "Lincolnshire Formation",
+            ["Brassfield Formation"] = "Brassfield Limestone",
+            ["Leipers"] = "Leipers Formation",
+            ["Leipers Limestone"] = "Leipers Formation",
+            ["Longview"] = "Longview Dolomite",
+            ["Kingsport"] = "Kingsport Dolomite",
+            ["Fort Payne"] = "Fort Payne Formation",
+            ["Fernvale"] = "Fernvale Limestone",
+            ["Fervale"] = "Fernvale Limestone",
+            ["Arnheim"] = "Arnheim Formation",
+            ["Laurel"] = "Laurel Limestone",
+            ["Raccoon Mountain"] = "Raccoon Mountain Formation"
+        };
+
+    private static readonly Dictionary<string, string> GroupedGeologyCanonicalNames =
+        new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["Hurricance Bridge and Woodway Limestones Undivid"] =
+                "Hurricane Bridge & Woodway Limestones Undivided",
+            ["Chepultepec, Longview and Newala Dols. Undiff."] =
+                "Chepultepec & Longview & Newala Dolomites Undifferentiated",
+            ["Kingsport, Longview, Chepultepec Undifferentiated"] =
+                "Kingsport & Longview & Chepultepec Undifferentiated",
+            ["Jonesboro, Mosheim, Lenoir Ls Undivided"] =
+                "Jonesboro & Mosheim & Lenoir Limestones Undivided",
+            ["Crooked Fork Group and Rockcastle Undiff."] =
+                "Crooked Fork Group & Rockcastle Undifferentiated",
+            ["Vandever, Newton, and Whitwell Formation, Undiff"] =
+                "Vandever & Newton & Whitwell Formation Undifferentiated",
+            ["Fort Payne Formation and Hardin SS and Wayne Group"] =
+                "Fort Payne Formation & Hardin Sandstone & Wayne Group",
+            ["Devonian and Silurian Undifferentiated"] =
+                "Devonian & Silurian Undifferentiated"
+        };
+
+    private static readonly Dictionary<string, string> GeologicAgeCanonicalNames =
+        new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["Miss"] = "Mississippian",
+            ["Dev"] = "Devonian",
+            ["Devon"] = "Devonian",
+            ["Ord"] = "Ordovician",
+            ["Ordov"] = "Ordovician",
+            ["Penn"] = "Pennsylvanian",
+            ["Sil"] = "Silurian"
+        };
+
+    private static readonly Dictionary<string, string> GroupedGeologicAgeCanonicalNames =
+        new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["Dev & Sil Und"] = "Devonian & Silurian Undifferentiated"
+        };
+
+    private static readonly Dictionary<string, string> PhysiographicProvinceCanonicalNames =
+        new(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["Sequatchie  Valley"] = "Sequatchie Valley",
+            ["Unaka Mtns & Blue Ridge"] = "Unaka Mountains & Blue Ridge",
+            ["Gulf & Atlantic Costal Plains Undiff."] = "Gulf & Atlantic Coastal Plains Undifferentiated"
+        };
+
+    internal enum TagSeparatorPolicy
+    {
+        CommaOnly,
+        Geology,
+        GeologicAge
+    }
+
     public static void Main()
     {
         const string filePath = "/Users/michaelketzner/Downloads/TCSnarr.csv";
@@ -50,17 +138,17 @@ public partial class Program
             }
 
             var mapStatuses = cave.MapStatus;
-            var geology = ExtractTags((null, cave.CaveGeology));
-            var geologyAge = ExtractTags((null, cave.GeologicalAge));
+            var geology = ExtractGeologyTags(cave.CaveGeology);
+            var geologyAge = ExtractGeologicAgeTags(cave.GeologicalAge);
 
-            var physiographicProvinces = cave.PhysiographicProvince;
+            var physiographicProvinces = NormalizePhysiographicProvince(cave.PhysiographicProvince);
             var reportedOnDate = ExtractReportedOnDate(cave.Narrative);
             var reportedBy = ExtractReportedBy(cave.Narrative);
 
             #region TCS Specific Tags
 
             var otherTags =
-                ExtractTags(("Gear", cave.RequiredGear), ("Entrance Type", cave.EntranceType));
+                ExtractCommaSeparatedTags(("Gear", cave.RequiredGear), ("Entrance Type", cave.EntranceType));
 
             #endregion
 
@@ -129,9 +217,9 @@ public partial class Program
             #region TCS Specific Tags
 
             var ownershipTags =
-                ExtractTags((null, entrance.Ownership));
+                ExtractCommaSeparatedTags((null, entrance.Ownership));
 
-            var fieldIndicationTags = ExtractTags((null, entrance.FieldIndication));
+            var fieldIndicationTags = ExtractCommaSeparatedTags((null, entrance.FieldIndication));
 
 
             #endregion
@@ -173,27 +261,85 @@ public partial class Program
         return null;
     }
 
-    private static string ExtractTags(params (string? prefix, string? input)[] inputs)
+    internal static string ExtractGeologyTags(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return string.Empty;
+        }
+
+        var normalizedInput = NormalizeGeologyInput(input);
+
+        if (IsGroupedGeologyUnit(normalizedInput))
+        {
+            return NormalizeGroupedGeologyTag(normalizedInput);
+        }
+
+        return ExtractTags(TagSeparatorPolicy.Geology, (null, normalizedInput));
+    }
+
+    internal static string ExtractGeologicAgeTags(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return string.Empty;
+        }
+
+        var normalizedInput = NormalizeGeologicAgeInput(input);
+
+        if (IsGroupedGeologicAgeUnit(normalizedInput))
+        {
+            return NormalizeGroupedGeologicAgeTag(normalizedInput);
+        }
+
+        return ExtractTags(TagSeparatorPolicy.GeologicAge, (null, normalizedInput));
+    }
+
+    internal static string ExtractCommaSeparatedTags(params (string? prefix, string? input)[] inputs)
+    {
+        return ExtractTags(TagSeparatorPolicy.CommaOnly, inputs);
+    }
+
+    internal static string? NormalizePhysiographicProvince(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return input;
+        }
+
+        var normalizedInput = Regex.Replace(input.Trim(), @"\s+", " ");
+
+        if (PhysiographicProvinceCanonicalNames.TryGetValue(input.Trim(), out var canonicalName))
+        {
+            return canonicalName;
+        }
+
+        if (PhysiographicProvinceCanonicalNames.TryGetValue(normalizedInput, out canonicalName))
+        {
+            return canonicalName;
+        }
+
+        return normalizedInput;
+    }
+
+    private static string ExtractTags(TagSeparatorPolicy separatorPolicy, params (string? prefix, string? input)[] inputs)
     {
         var tagsList = new List<string>();
-        string[] separators = { ",", "and", "&", "AND" };
+        var seenTags = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
 
         foreach (var (prefix, input) in inputs)
         {
             if (string.IsNullOrWhiteSpace(input))
                 continue;
 
-            // Split the input using the separators
-            var tags = input.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (var tag in tags)
+            foreach (var tag in SplitTags(input, separatorPolicy))
             {
-                var trimmedTag = tag.Trim();
+                var trimmedTag = NormalizeTag(tag, separatorPolicy);
                 if (!string.IsNullOrWhiteSpace(prefix))
                 {
                     trimmedTag = $"{prefix}: {trimmedTag}";
                 }
-                if (!string.IsNullOrWhiteSpace(trimmedTag))
+                if (!string.IsNullOrWhiteSpace(trimmedTag) && seenTags.Add(trimmedTag))
                 {
                     tagsList.Add(trimmedTag);
                 }
@@ -201,6 +347,129 @@ public partial class Program
         }
 
         return string.Join(", ", tagsList);
+    }
+
+    private static string NormalizeTag(string input, TagSeparatorPolicy separatorPolicy)
+    {
+        var normalizedTag = Regex.Replace(input.Trim(), @"\s+", " ");
+
+        if (separatorPolicy == TagSeparatorPolicy.Geology)
+        {
+            normalizedTag = NormalizeGeologyTag(normalizedTag);
+        }
+        else if (separatorPolicy == TagSeparatorPolicy.GeologicAge)
+        {
+            normalizedTag = NormalizeGeologicAgeTag(normalizedTag);
+        }
+        else if (normalizedTag.Equals("Artifical Tunnel", StringComparison.InvariantCultureIgnoreCase))
+        {
+            normalizedTag = "Artificial Tunnel";
+        }
+        else if (normalizedTag.Equals("Large, walk-in", StringComparison.InvariantCultureIgnoreCase))
+        {
+            normalizedTag = "Large/Walk-in";
+        }
+
+        return normalizedTag;
+    }
+
+    private static string NormalizeGeologyTag(string input)
+    {
+        var normalized = input.Trim();
+
+        if (GeologyCanonicalNames.TryGetValue(normalized, out var canonicalName))
+        {
+            return canonicalName;
+        }
+
+        return normalized;
+    }
+
+    private static string NormalizeGeologicAgeTag(string input)
+    {
+        if (GeologicAgeCanonicalNames.TryGetValue(input.Trim(), out var canonicalName))
+        {
+            return canonicalName;
+        }
+
+        return input.Trim();
+    }
+
+    private static string NormalizeGroupedGeologyTag(string input)
+    {
+        var lookupKey = Regex.Replace(input, @"\s*&\s*", " and ");
+
+        if (GroupedGeologyCanonicalNames.TryGetValue(lookupKey, out var canonicalName))
+        {
+            return canonicalName;
+        }
+
+        return input;
+    }
+
+    private static string NormalizeGroupedGeologicAgeTag(string input)
+    {
+        if (GroupedGeologicAgeCanonicalNames.TryGetValue(input, out var canonicalName))
+        {
+            return canonicalName;
+        }
+
+        return input;
+    }
+
+    private static string NormalizeGeologyInput(string input)
+    {
+        var normalized = Regex.Replace(input.Trim(), @"\s+", " ");
+        normalized = Regex.Replace(normalized, @"\s*,\s*", ", ");
+        normalized = Regex.Replace(normalized, @"\s*&\s*", " & ");
+        normalized = Regex.Replace(normalized, @"\s+and\s+", " and ", RegexOptions.IgnoreCase);
+
+        return normalized;
+    }
+
+    private static string NormalizeGeologicAgeInput(string input)
+    {
+        var normalized = Regex.Replace(input.Trim(), @"\s+", " ");
+        normalized = Regex.Replace(normalized, @"\s*,\s*", ", ");
+        normalized = Regex.Replace(normalized, @"\s*&\s*", " & ");
+        normalized = Regex.Replace(normalized, @"\s+and\s+", " & ", RegexOptions.IgnoreCase);
+
+        return normalized;
+    }
+
+    private static bool IsGroupedGeologyUnit(string input)
+    {
+        return GroupedGeologySuffixRegex().IsMatch(input) &&
+               (input.Contains(',') || input.Contains('&') || GeologyAndSeparatorRegex().IsMatch(input));
+    }
+
+    private static bool IsGroupedGeologicAgeUnit(string input)
+    {
+        return GroupedGeologicAgeCanonicalNames.ContainsKey(input);
+    }
+
+    private static IEnumerable<string> SplitTags(string input, TagSeparatorPolicy separatorPolicy)
+    {
+        var tags = input
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .AsEnumerable();
+
+        if (separatorPolicy == TagSeparatorPolicy.Geology)
+        {
+            tags = tags
+                .SelectMany(tag => tag.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                .SelectMany(tag => GeologyAndSeparatorRegex()
+                    .Split(tag)
+                    .Where(part => !string.IsNullOrWhiteSpace(part))
+                    .Select(part => part.Trim()));
+        }
+        else if (separatorPolicy == TagSeparatorPolicy.GeologicAge)
+        {
+            tags = tags
+                .SelectMany(tag => tag.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        return tags;
     }
 
     private static List<CaveRecord> ReadCavesFromCsv(string filePath)
@@ -255,6 +524,11 @@ public partial class Program
     private static partial Regex CaveIdRegex();
 
     [GeneratedRegex(@"^[A-Z]{2}\d+")]
-
     private static partial Regex CaveIdRegexWithinString();
+
+    [GeneratedRegex(@"\s+and\s+", RegexOptions.IgnoreCase)]
+    private static partial Regex GeologyAndSeparatorRegex();
+
+    [GeneratedRegex(@"Undivid(?:ed)?|Undiff(?:erentiated)?", RegexOptions.IgnoreCase)]
+    private static partial Regex GroupedGeologySuffixRegex();
 }

--- a/Import/Import/Tcs/Tcs.csproj
+++ b/Import/Import/Tcs/Tcs.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <UseAppHost>false</UseAppHost>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Updated the TCS conversion project to fix issues with the tags
- It normalizes all of the tags (for example, spelling errors, removes abbreviations in favor for full words)
- It separates them when it makes sense (splits Hartselle Formation and Monteagle Limestone but not Hurricance Bridge & Woodway Limestones Undivid
- multiple mappings for columns because Gerald changes them