### PR TITLE
Import Existing Caves/Entrances

### DIFF
--- a/Planarian.Web/src/Modules/Account/Services/AccountService.ts
+++ b/Planarian.Web/src/Modules/Account/Services/AccountService.ts
@@ -101,10 +101,11 @@ const AccountService = {
   },
   async ImportCavesFileProcess(
     fileId: string,
-    isDryRun = false
+    isDryRun = false,
+    syncExisting = false
   ): Promise<CaveDryRunRecord[]> {
     const response = await HttpClient.post<CaveDryRunRecord[]>(
-      `${baseUrl}/import/caves/process/${fileId}?isDryRun=${isDryRun}`
+      `${baseUrl}/import/caves/process/${fileId}?isDryRun=${isDryRun}&syncExisting=${syncExisting}`
     );
     return response.data;
   },
@@ -132,10 +133,11 @@ const AccountService = {
   },
   async ImportEntrancesProcess(
     fileId: string,
-    isDryRun: boolean
+    isDryRun: boolean,
+    syncExisting = false
   ): Promise<EntranceDryRun[]> {
     const response = await HttpClient.post<EntranceDryRun[]>(
-      `${baseUrl}/import/entrances/process/${fileId}?isDryRun=${isDryRun}`
+      `${baseUrl}/import/entrances/process/${fileId}?isDryRun=${isDryRun}&syncExisting=${syncExisting}`
     );
     return response.data;
   },

--- a/Planarian.Web/src/Modules/Import/Components/ImportCaves.tsx
+++ b/Planarian.Web/src/Modules/Import/Components/ImportCaves.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Result, Button, message, Spin } from "antd";
+import { Card, Result, Button, Checkbox, message, Spin } from "antd";
 import {
   DeliveredProcedureOutlined,
   CheckCircleOutlined,
@@ -30,6 +30,38 @@ interface ImportCaveComponentProps {
   onUploaded: () => void;
 }
 
+const buildDryRunCsv = (records: CaveDryRunRecord[]): string =>
+  Papa.unparse(
+    records
+      .filter((record) => record.action !== "no change")
+      .map((record) => ({
+        countyCode: record.countyCode,
+        countyCaveNumber: record.countyCaveNumber,
+        caveName: record.caveName,
+        changesSummary: record.changesSummary,
+        action: record.action,
+        state: record.state,
+        countyName: record.countyName,
+        alternateNames: record.alternateNames,
+        caveLengthFeet: record.caveLengthFeet,
+        caveDepthFeet: record.caveDepthFeet,
+        maxPitDepthFeet: record.maxPitDepthFeet,
+        numberOfPits: record.numberOfPits,
+        reportedOnDate: record.reportedOnDate,
+        isArchived: record.isArchived,
+        geology: record.geology,
+        reportedByNames: record.reportedByNames,
+        biology: record.biology,
+        archeology: record.archeology,
+        cartographerNames: record.cartographerNames,
+        geologicAges: record.geologicAges,
+        physiographicProvinces: record.physiographicProvinces,
+        otherTags: record.otherTags,
+        mapStatuses: record.mapStatuses,
+        narrative: record.narrative,
+      }))
+  );
+
 const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
   onUploaded,
 }) => {
@@ -47,6 +79,7 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [dryRunData, setDryRunData] = useState<CaveDryRunRecord[]>([]);
   const [isDryRunComplete, setIsDryRunComplete] = useState(false);
+  const [syncExisting, setSyncExisting] = useState(false);
 
   // Handlers and functions
   const showCSVModal = () => setIsModalOpen(true);
@@ -70,9 +103,20 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
     try {
       const result = await AccountService.ImportCavesFileProcess(
         uploadResult.id,
-        true
+        true,
+        syncExisting
       );
-      setDryRunData(result);
+      const changedRecords = result.filter(
+        (record) => record.action !== "no change"
+      );
+
+      if (changedRecords.length === 0) {
+        message.info("Dry run found no changes. The import has been reset.");
+        resetStates();
+        return;
+      }
+
+      setDryRunData(changedRecords);
       setIsDryRunComplete(true);
     } catch (e) {
       const error = e as ImportApiErrorResponse<CaveCsvModel>;
@@ -93,7 +137,7 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
     setIsLoading(true);
     setIsProcessing(true);
     try {
-      await AccountService.ImportCavesFileProcess(uploadResult.id);
+      await AccountService.ImportCavesFileProcess(uploadResult.id, false, syncExisting);
       setIsProcessed(true);
     } catch (e) {
       const error = e as ImportApiErrorResponse<CaveCsvModel>;
@@ -119,6 +163,7 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
     setUploadResult(undefined);
     setDryRunData([]);
     setIsDryRunComplete(false);
+    setSyncExisting(false);
   };
 
   return (
@@ -190,6 +235,12 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
               title="Successfully Uploaded!"
               subTitle="Click the dry run button below to preview the changes. If not, no caves will be imported."
               extra={[
+                <Checkbox
+                  checked={syncExisting}
+                  onChange={(event) => setSyncExisting(event.target.checked)}
+                >
+                  Update existing caves and delete caves missing from the CSV
+                </Checkbox>,
                 <PlanarianButton
                   onClick={handleDryRunClick}
                   icon={<EyeOutlined />}
@@ -310,7 +361,7 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
           onClose={handleOk}
           footer={null}
         >
-          <CSVDisplay data={Papa.unparse(dryRunData)} />
+          <CSVDisplay data={buildDryRunCsv(dryRunData)} />
         </PlanarianModal>
       )}
     </>

--- a/Planarian.Web/src/Modules/Import/Components/ImportCaves.tsx
+++ b/Planarian.Web/src/Modules/Import/Components/ImportCaves.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Result, Button, Checkbox, message, Spin } from "antd";
+import { Card, Result, Button, Radio, message, Spin } from "antd";
 import {
   DeliveredProcedureOutlined,
   CheckCircleOutlined,
@@ -7,6 +7,7 @@ import {
   EyeOutlined,
 } from "@ant-design/icons";
 import Papa from "papaparse";
+import { Link } from "react-router-dom";
 
 // Importing components and services
 import { UploadComponent } from "../../Files/Components/UploadComponent";
@@ -233,25 +234,62 @@ const ImportCaveComponent: React.FC<ImportCaveComponentProps> = ({
             <Result
               icon={<CheckCircleOutlined style={{ color: "#52c41a" }} />}
               title="Successfully Uploaded!"
-              subTitle="Click the dry run button below to preview the changes. If not, no caves will be imported."
+              subTitle="Run a dry run to preview exactly what will happen before applying the cave import."
               extra={[
-                <Checkbox
-                  checked={syncExisting}
-                  onChange={(event) => setSyncExisting(event.target.checked)}
+                <div
+                  key="sync-actions"
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 12,
+                  }}
                 >
-                  Update existing caves and delete caves missing from the CSV
-                </Checkbox>,
-                <PlanarianButton
-                  onClick={handleDryRunClick}
-                  icon={<EyeOutlined />}
-                  loading={isLoading}
-                  type="primary"
-                >
-                  Dry Run
-                </PlanarianButton>,
-                <PlanarianButton onClick={tryAgain} icon={<RedoOutlined />}>
-                  Reset
-                </PlanarianButton>,
+                  <Radio.Group
+                    value={syncExisting ? "upsert" : "insert"}
+                    onChange={(event) =>
+                      setSyncExisting(event.target.value === "upsert")
+                    }
+                    optionType="button"
+                    buttonStyle="solid"
+                  >
+                    <Radio.Button value="insert">Insert Only</Radio.Button>
+                    <Radio.Button value="upsert">Insert / Update</Radio.Button>
+                  </Radio.Group>
+                  <div
+                    style={{
+                      maxWidth: 560,
+                      textAlign: "center",
+                    }}
+                  >
+                    {syncExisting
+                      ? "Updates the caves in the database to match this CSV. Matching caves will be updated, new caves will be inserted, and caves missing from the CSV will be deleted. Files, favorites, and other related records are only affected if a cave is deleted. "
+                      : "Only new caves will be inserted. The import will fail if the CSV includes a cave that already exists. "}
+                    <strong>It is strongly recommended</strong> to create an
+                    archive before running either mode. You can create one in{" "}
+                    <Link to="/account/settings">Account Settings</Link>.
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <PlanarianButton
+                      onClick={handleDryRunClick}
+                      icon={<EyeOutlined />}
+                      loading={isLoading}
+                      type="primary"
+                    >
+                      Dry Run
+                    </PlanarianButton>
+                    <PlanarianButton onClick={tryAgain} icon={<RedoOutlined />}>
+                      Reset
+                    </PlanarianButton>
+                  </div>
+                </div>,
               ]}
             />
           </Card>

--- a/Planarian.Web/src/Modules/Import/Components/ImportEntrances.tsx
+++ b/Planarian.Web/src/Modules/Import/Components/ImportEntrances.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Result, Button, message } from "antd";
+import { Card, Result, Button, Checkbox, message } from "antd";
 import {
   DeliveredProcedureOutlined,
   CheckCircleOutlined,
@@ -48,6 +48,7 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [dryRunData, setDryRunData] = useState<EntranceDryRun[]>([]);
   const [isDryRunComplete, setIsDryRunComplete] = useState(false);
+  const [syncExisting, setSyncExisting] = useState(false);
 
   // Handlers and functions
   const showCSVModal = () => setIsModalOpen(true);
@@ -71,7 +72,8 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
     try {
       const result = await AccountService.ImportEntrancesProcess(
         uploadResult.id,
-        true
+        true,
+        syncExisting
       );
       setDryRunData(result);
       setIsDryRunComplete(true);
@@ -93,7 +95,11 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
     setIsLoading(true);
     setIsProcessing(true);
     try {
-      await AccountService.ImportEntrancesProcess(uploadResult.id, false);
+      await AccountService.ImportEntrancesProcess(
+        uploadResult.id,
+        false,
+        syncExisting
+      );
       setIsProcessed(true);
     } catch (e) {
       const error = e as ImportApiErrorResponse<EntranceCsvModel>;
@@ -118,6 +124,7 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
     setUploadResult(undefined);
     setDryRunData([]);
     setIsDryRunComplete(false);
+    setSyncExisting(false);
   };
 
   return (
@@ -189,6 +196,12 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
               title="Successfully Uploaded!"
               subTitle="Click the dry run button below to preview the changes. If not, no entrances will be imported."
               extra={[
+                <Checkbox
+                  checked={syncExisting}
+                  onChange={(event) => setSyncExisting(event.target.checked)}
+                >
+                  Update existing entrances and delete entrances missing from the CSV
+                </Checkbox>,
                 <PlanarianButton
                   onClick={handleDryRunClick}
                   icon={<EyeOutlined />}
@@ -210,7 +223,7 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
           <Result
             icon={<CheckCircleOutlined style={{ color: "#52c41a" }} />}
             title="Dry Run Complete!"
-            subTitle="Review the changes below. If everything looks good, proceed with processing."
+            subTitle="Review the changes below. A count change of 0 means the number of entrances is unchanged, not that the entrance data itself is unchanged."
             extra={[
               <PlanarianButton
                 alwaysShowChildren

--- a/Planarian.Web/src/Modules/Import/Components/ImportEntrances.tsx
+++ b/Planarian.Web/src/Modules/Import/Components/ImportEntrances.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Result, Button, Checkbox, message } from "antd";
+import { Card, Result, Button, Radio, message } from "antd";
 import {
   DeliveredProcedureOutlined,
   CheckCircleOutlined,
@@ -194,25 +194,64 @@ const ImportEntrancesComponent: React.FC<ImportEntrancesComponentProps> = ({
             <Result
               icon={<CheckCircleOutlined style={{ color: "#52c41a" }} />}
               title="Successfully Uploaded!"
-              subTitle="Click the dry run button below to preview the changes. If not, no entrances will be imported."
+              subTitle="Run a dry run to preview exactly what will happen before applying the entrance import."
               extra={[
-                <Checkbox
-                  checked={syncExisting}
-                  onChange={(event) => setSyncExisting(event.target.checked)}
+                <div
+                  key="sync-actions"
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 12,
+                  }}
                 >
-                  Update existing entrances and delete entrances missing from the CSV
-                </Checkbox>,
-                <PlanarianButton
-                  onClick={handleDryRunClick}
-                  icon={<EyeOutlined />}
-                  loading={isLoading}
-                  type="primary"
-                >
-                  Dry Run
-                </PlanarianButton>,
-                <Button onClick={tryAgain} icon={<RedoOutlined />}>
-                  Reset
-                </Button>,
+                  <Radio.Group
+                    value={syncExisting ? "replace" : "insert"}
+                    onChange={(event) =>
+                      setSyncExisting(event.target.value === "replace")
+                    }
+                    optionType="button"
+                    buttonStyle="solid"
+                  >
+                    <Radio.Button value="insert">Insert Only</Radio.Button>
+                    <Radio.Button value="replace">
+                      Replace Existing
+                    </Radio.Button>
+                  </Radio.Group>
+                  <div
+                    style={{
+                      maxWidth: 560,
+                      textAlign: "center",
+                    }}
+                  >
+                    {syncExisting
+                      ? "For caves included in this CSV, existing entrances will be deleted and replaced with the entrances in the file. "
+                      : "Only new entrances will be inserted. Existing entrances are left unchanged. "}
+                    <strong>It is strongly recommended</strong> to create an
+                    archive before running either mode. You can create one in{" "}
+                    <Link to="/account/settings">Account Settings</Link>.
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <PlanarianButton
+                      onClick={handleDryRunClick}
+                      icon={<EyeOutlined />}
+                      loading={isLoading}
+                      type="primary"
+                    >
+                      Dry Run
+                    </PlanarianButton>
+                    <Button onClick={tryAgain} icon={<RedoOutlined />}>
+                      Reset
+                    </Button>
+                  </div>
+                </div>,
               ]}
             />
           </Card>

--- a/Planarian.Web/src/Modules/Import/Models/CaveDryRunRecord.ts
+++ b/Planarian.Web/src/Modules/Import/Models/CaveDryRunRecord.ts
@@ -1,4 +1,6 @@
 export interface CaveDryRunRecord {
+  action: string;
+  changesSummary: string | null;
   state: string;
   countyName: string;
   countyCode: string;

--- a/Planarian.Web/src/Modules/Import/Models/EntranceDryRun.ts
+++ b/Planarian.Web/src/Modules/Import/Models/EntranceDryRun.ts
@@ -1,5 +1,6 @@
 export interface EntranceDryRun {
   associatedCave: string;
+  entranceCountChange: number;
   locationQuality: string;
   isPrimaryEntrance: boolean;
   entranceName: string | null;

--- a/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
+++ b/Planarian/Planarian.Model/Interceptors/SaveChangesInterceptor.cs
@@ -47,7 +47,7 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
     {
         if (eventData.Context == null) return;
         
-        var context = (PlanarianDbContext)eventData.Context;
+        var context = (PlanarianDbContextBase)eventData.Context;
         foreach (var entityEntry in eventData.Context.ChangeTracker.Entries())
             if (entityEntry.Entity.GetType().BaseType == typeof(EntityBase) ||
                 entityEntry.Entity.GetType().BaseType == typeof(EntityBaseNameId))
@@ -90,7 +90,7 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
             }
     }
 
-    private async Task Validate(PlanarianDbContext context, EntityEntry entity, EntityState entityState)
+    private async Task Validate(PlanarianDbContextBase context, EntityEntry entity, EntityState entityState)
     {
         var name = entity.Entity.GetType().Name;
         switch (name)
@@ -320,4 +320,3 @@ public class  SaveChangesInterceptor : ISaveChangesInterceptor
         return Task.CompletedTask;
     }
 }
-

--- a/Planarian/Planarian/Modules/Account/Controller/AccountController.cs
+++ b/Planarian/Planarian/Modules/Account/Controller/AccountController.cs
@@ -151,9 +151,10 @@ public class AccountController : PlanarianControllerBase<AccountService>
     [Authorize(Policy = PermissionPolicyKey.Admin)]
     public async Task<IActionResult> ImportCavesFileProcess(string fileId,
         bool isDryRun,
+        bool syncExisting,
         CancellationToken cancellationToken)
     {
-        var result = await _importService.ImportCavesFileProcess(fileId, isDryRun, cancellationToken);
+        var result = await _importService.ImportCavesFileProcess(fileId, isDryRun, syncExisting, cancellationToken);
 
         return new JsonResult(result);
     }
@@ -189,9 +190,10 @@ public class AccountController : PlanarianControllerBase<AccountService>
     [Authorize(Policy = PermissionPolicyKey.Admin)]
     public async Task<IActionResult> ImportEntrancesFileProcess(string fileId,
         bool isDryRun,
+        bool syncExisting,
         CancellationToken cancellationToken)
     {
-        var result = await _importService.ImportEntrancesFileProcess(fileId, isDryRun, cancellationToken);
+        var result = await _importService.ImportEntrancesFileProcess(fileId, isDryRun, syncExisting, cancellationToken);
 
         return new JsonResult(result);
     }

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -19,7 +19,6 @@ using Planarian.Model.Shared.Base;
 using Planarian.Model.Shared.Helpers;
 using Planarian.Modules.Account.Repositories;
 using Planarian.Modules.Caves.Repositories;
-using Planarian.Modules.Caves.Services;
 using Planarian.Modules.Files.Repositories;
 using Planarian.Modules.Files.Services;
 using Planarian.Modules.Import.Models;
@@ -41,7 +40,6 @@ public class ImportService : ServiceBase
     private readonly AccountRepository<PlanarianDbContextBase> _accountRepository;
     private readonly CaveRepository<PlanarianDbContextBase> _repository;
     private readonly FileRepository<PlanarianDbContextBase> _fileRepository;
-    private readonly CaveService _caveService;
 
     public ImportService(RequestUser requestUser, FileService fileService,
         TagRepository<PlanarianDbContextBase> tagRepository,
@@ -50,8 +48,7 @@ public class ImportService : ServiceBase
         NotificationService notificationService,
         AccountRepository<PlanarianDbContextBase> accountRepository,
         CaveRepository<PlanarianDbContextBase> caveRepository,
-        FileRepository<PlanarianDbContextBase> fileRepository,
-        CaveService caveService) : base(requestUser)
+        FileRepository<PlanarianDbContextBase> fileRepository) : base(requestUser)
     {
         _fileService = fileService;
         _tagRepository = tagRepository;
@@ -61,7 +58,6 @@ public class ImportService : ServiceBase
         _accountRepository = accountRepository;
         _repository = caveRepository;
         _fileRepository = fileRepository;
-        _caveService = caveService;
     }
 
     public async Task<FileVm> AddTemporaryFileForImport(Stream stream, string fileName, string? uuid,
@@ -820,7 +816,9 @@ public class ImportService : ServiceBase
                 foreach (var caveId in caveIdsToDelete)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    await _caveService.DeleteCave(caveId, cancellationToken, transaction, deferredFileDeletes);
+                    var deletedCave = existingCaves.First(e => e.Id == caveId);
+                    await RequestUser.HasCavePermission(PermissionPolicyKey.Manager, caveId, deletedCave.CountyId);
+                    await _repository.DeleteImportSyncCave(caveId, deferredFileDeletes, cancellationToken);
                 }
 
                 await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished deleting missing caves.");

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -19,6 +19,7 @@ using Planarian.Model.Shared.Base;
 using Planarian.Model.Shared.Helpers;
 using Planarian.Modules.Account.Repositories;
 using Planarian.Modules.Caves.Repositories;
+using Planarian.Modules.Caves.Services;
 using Planarian.Modules.Files.Repositories;
 using Planarian.Modules.Files.Services;
 using Planarian.Modules.Import.Models;
@@ -40,6 +41,7 @@ public class ImportService : ServiceBase
     private readonly AccountRepository<PlanarianDbContextBase> _accountRepository;
     private readonly CaveRepository<PlanarianDbContextBase> _repository;
     private readonly FileRepository<PlanarianDbContextBase> _fileRepository;
+    private readonly CaveService _caveService;
 
     public ImportService(RequestUser requestUser, FileService fileService,
         TagRepository<PlanarianDbContextBase> tagRepository,
@@ -48,7 +50,8 @@ public class ImportService : ServiceBase
         NotificationService notificationService,
         AccountRepository<PlanarianDbContextBase> accountRepository,
         CaveRepository<PlanarianDbContextBase> caveRepository,
-        FileRepository<PlanarianDbContextBase> fileRepository) : base(requestUser)
+        FileRepository<PlanarianDbContextBase> fileRepository,
+        CaveService caveService) : base(requestUser)
     {
         _fileService = fileService;
         _tagRepository = tagRepository;
@@ -58,6 +61,7 @@ public class ImportService : ServiceBase
         _accountRepository = accountRepository;
         _repository = caveRepository;
         _fileRepository = fileRepository;
+        _caveService = caveService;
     }
 
     public async Task<FileVm> AddTemporaryFileForImport(Stream stream, string fileName, string? uuid,
@@ -90,6 +94,7 @@ public class ImportService : ServiceBase
     #region Cave Import
 
     public async Task<List<CaveDryRunRecord>> ImportCavesFileProcess(string temporaryFileId, bool isDryRun,
+        bool syncExisting,
         CancellationToken cancellationToken)
     {
         if (RequestUser.AccountId == null) throw ApiExceptionDictionary.NoAccount;
@@ -242,7 +247,17 @@ public class ImportService : ServiceBase
 
             #endregion
 
-
+            var existingCaves = syncExisting ? await _repository.GetImportSyncCaves() : new List<ImportSyncCaveLookup>();
+            var existingByKey = existingCaves.ToDictionary(
+                cave => $"{cave.StateId}:{cave.CountyId}:{cave.CountyNumber}",
+                cave => cave);
+            var caveIdsToDelete = existingCaves.Select(e => e.Id).ToHashSet();
+            var caveActionsById = new Dictionary<string, string>();
+            var caveChangeSummariesById = new Dictionary<string, string?>();
+            var seenCsvKeys = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            var newCavesForInsert = new List<Cave>();
+            var cavesForUpdate = new List<Cave>();
+            var deferredFileDeletes = new List<Planarian.Model.Database.Entities.RidgeWalker.File>();
             var usedCountyNumbers = await _repository.GetUsedCountyNumbers();
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Started processing caves");
             var rowNumber = 1; // start at 1 to account for header row
@@ -309,11 +324,25 @@ public class ImportService : ServiceBase
                         continue;
                     }
 
+                    ImportSyncCaveLookup? existingCaveLookup = null;
+                    if (syncExisting)
+                    {
+                        var caveKey = $"{state.Id}:{county.Id}:{caveRecord.CountyCaveNumber}";
+                        if (!seenCsvKeys.Add(caveKey))
+                        {
+                            failedRecords.Add(new FailedCaveCsvRecord<CaveCsvModel>(caveRecord, rowNumber,
+                                $"Duplicate cave key found for {caveRecord.CountyCode}-{caveRecord.CountyCaveNumber}."));
+                            continue;
+                        }
+
+                        existingByKey.TryGetValue(caveKey, out existingCaveLookup);
+                    }
+
                     var isValidReportedOn = DateTime.TryParse(caveRecord.ReportedOnDate, out var reportedOnDate);
                     reportedOnDate = reportedOnDate.ToUtcKind();
                     var cave = new Cave
                     {
-                        Id = IdGenerator.Generate(),
+                        Id = existingCaveLookup?.Id ?? IdGenerator.Generate(),
                         Name = caveRecord.CaveName.Trim(),
                         AccountId = RequestUser.AccountId,
                         LengthFeet = caveRecord.CaveLengthFt,
@@ -547,7 +576,7 @@ public class ImportService : ServiceBase
                             cave.CartographerNameTags.Add(cartographerTag);
                         }
                     }
-                    
+
                     if (caveRecord.ReportedByNames != null)
                     {
                         var reportedByNames = caveRecord.ReportedByNames.SplitAndTrim()
@@ -556,7 +585,7 @@ public class ImportService : ServiceBase
                         {
                             var tag = allPeopleTags.FirstOrDefault(e =>
                                 e.Name.Equals(reportedByName, StringComparison.InvariantCultureIgnoreCase));
-                            
+
                             if (tag == null)
                             {
                                 failedRecords.Add(new FailedCaveCsvRecord<CaveCsvModel>(caveRecord, rowNumber,
@@ -577,13 +606,46 @@ public class ImportService : ServiceBase
                                 CreatedOn = DateTime.UtcNow,
                                 CreatedByUserId = RequestUser.Id
                             };
-                            
+
                             cave.CaveReportedByNameTags.Add(reportedByTag);
                         }
                     }
 
-                    var isValidCave = IsValidCave(cave, usedCountyNumbers, caveRecord, rowNumber, failedRecords);
+                    var isValidCave = IsValidCave(cave, usedCountyNumbers, caveRecord, rowNumber, failedRecords,
+                        skipCountyNumberConflictCheck: syncExisting);
                     if (!isValidCave) continue;
+
+                    if (existingCaveLookup != null)
+                    {
+                        caveIdsToDelete.Remove(existingCaveLookup.Id);
+                        var changeSummary = BuildCaveChangeSummary(
+                            existingCaveLookup,
+                            cave,
+                            allGeologyTags.ToDictionary(e => e.Id, e => e.Name),
+                            allGeologicAgeTags.ToDictionary(e => e.Id, e => e.Name),
+                            allMapStatusTags.ToDictionary(e => e.Id, e => e.Name),
+                            allPhysiographicProvincesTags.ToDictionary(e => e.Id, e => e.Name),
+                            allArcheologyTags.ToDictionary(e => e.Id, e => e.Name),
+                            allBiologyTags.ToDictionary(e => e.Id, e => e.Name),
+                            allOtherTags.ToDictionary(e => e.Id, e => e.Name),
+                            allPeopleTags.ToDictionary(e => e.Id, e => e.Name));
+                        caveActionsById[cave.Id] = string.IsNullOrWhiteSpace(changeSummary)
+                            ? "no change"
+                            : "update";
+                        caveChangeSummariesById[cave.Id] = changeSummary;
+                        cavesForUpdate.Add(cave);
+                    }
+                    else if (syncExisting)
+                    {
+                        caveActionsById[cave.Id] = "insert";
+                        caveChangeSummariesById[cave.Id] = null;
+                        newCavesForInsert.Add(cave);
+                    }
+                    else
+                    {
+                        caveActionsById[cave.Id] = "insert";
+                        caveChangeSummariesById[cave.Id] = null;
+                    }
 
                     caves.Add(cave);
                 }
@@ -603,33 +665,44 @@ public class ImportService : ServiceBase
                 throw ApiExceptionDictionary.InvalidImport(failedRecords, ImportType.Cave);
             }
 
-            await _notificationService.SendNotificationToGroupAsync(signalRGroup,
-                "Inserting caves. This may take a while...");
+            if (syncExisting)
+            {
+                var updatedCaveIds = cavesForUpdate.Select(e => e.Id).ToList();
+                await _repository.BulkUpdateImportCaves(cavesForUpdate, cancellationToken);
+                await _repository.DeleteImportSyncCaveTags(updatedCaveIds, cancellationToken);
+            }
+
+            var cavesForInsert = syncExisting ? newCavesForInsert : caves;
+            var cavesForTagInsert = syncExisting ? cavesForUpdate.Concat(cavesForInsert).ToList() : caves;
 
             var config = new BulkConfig
             {
-                // TODO: exclude the generated tsvector column. I feel like this should auto-exclude but it isn't...
                 PropertiesToExclude = new List<string> { nameof(Cave.NarrativeSearchVector) }
             };
-            await _repository.BulkInsertAsync(caves, onBatchProcessed: OnBatchProcessed,
-                cancellationToken: cancellationToken, bulkConfig:config);
-            await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting caves!");
+            if (cavesForInsert.Any())
+            {
+                await _notificationService.SendNotificationToGroupAsync(signalRGroup,
+                    "Inserting caves. This may take a while...");
+                await _repository.BulkInsertAsync(cavesForInsert, onBatchProcessed: OnBatchProcessed,
+                    cancellationToken: cancellationToken, bulkConfig: config);
+                await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting caves!");
+            }
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting geology tags.");
-            var geologyTagsForInsert = caves.SelectMany(e => e.GeologyTags).ToList();
+            var geologyTagsForInsert = cavesForTagInsert.SelectMany(e => e.GeologyTags).ToList();
             await _repository.BulkInsertAsync(geologyTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting geology tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting geologic age tags.");
-            var geologicAgeTagsForInsert = caves.SelectMany(e => e.GeologicAgeTags).ToList();
+            var geologicAgeTagsForInsert = cavesForTagInsert.SelectMany(e => e.GeologicAgeTags).ToList();
             await _repository.BulkInsertAsync(geologicAgeTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Finished inserting geologic age tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting map status tags.");
-            var mapStatusTagsForInsert = caves.SelectMany(e => e.MapStatusTags).ToList();
+            var mapStatusTagsForInsert = cavesForTagInsert.SelectMany(e => e.MapStatusTags).ToList();
             await _repository.BulkInsertAsync(mapStatusTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
@@ -637,40 +710,40 @@ public class ImportService : ServiceBase
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Inserting physiographic province tags.");
-            var physiographicProvinceTagsForInsert = caves.SelectMany(e => e.PhysiographicProvinceTags).ToList();
+            var physiographicProvinceTagsForInsert = cavesForTagInsert.SelectMany(e => e.PhysiographicProvinceTags).ToList();
             await _repository.BulkInsertAsync(physiographicProvinceTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Finished inserting physiographic province tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting archeology tags.");
-            var archeologyTagsForInsert = caves.SelectMany(e => e.ArcheologyTags).ToList();
+            var archeologyTagsForInsert = cavesForTagInsert.SelectMany(e => e.ArcheologyTags).ToList();
             await _repository.BulkInsertAsync(archeologyTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Finished inserting archeology tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting biology tags.");
-            var biologyTagsForInsert = caves.SelectMany(e => e.BiologyTags).ToList();
+            var biologyTagsForInsert = cavesForTagInsert.SelectMany(e => e.BiologyTags).ToList();
             await _repository.BulkInsertAsync(biologyTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting biology tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting other tags.");
-            var otherTagsForInsert = caves.SelectMany(e => e.CaveOtherTags).ToList();
+            var otherTagsForInsert = cavesForTagInsert.SelectMany(e => e.CaveOtherTags).ToList();
             await _repository.BulkInsertAsync(otherTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished inserting other tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting cartographer tags.");
-            var cartographerTagsForInsert = caves.SelectMany(e => e.CartographerNameTags).ToList();
+            var cartographerTagsForInsert = cavesForTagInsert.SelectMany(e => e.CartographerNameTags).ToList();
             await _repository.BulkInsertAsync(cartographerTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
                 "Finished inserting cartographer tags.");
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Inserting reported by tags.");
-            var reportedByTagsForInsert = caves.SelectMany(e => e.CaveReportedByNameTags).ToList();
+            var reportedByTagsForInsert = cavesForTagInsert.SelectMany(e => e.CaveReportedByNameTags).ToList();
             await _repository.BulkInsertAsync(reportedByTagsForInsert, onBatchProcessed: OnBatchProcessed,
                 cancellationToken: cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
@@ -680,18 +753,24 @@ public class ImportService : ServiceBase
 
             foreach (var cave in caves)
             {
+                if (isDryRun && caveActionsById[cave.Id] == "no change")
+                {
+                    continue;
+                }
+
                 var record = new CaveDryRunRecord();
-                record.State = stateEntities.First(e => e.Id == cave.StateId).Abbreviation;
-                record.CountyName = allCounties.First(e => e.Id == cave.CountyId).Name;
                 record.CountyCode = allCounties.First(e => e.Id == cave.CountyId).DisplayId;
                 record.CountyCaveNumber = cave.CountyNumber;
                 record.CaveName = cave.Name;
+                record.ChangesSummary = caveChangeSummariesById[cave.Id];
+                record.Action = caveActionsById[cave.Id];
+                record.State = stateEntities.First(e => e.Id == cave.StateId).Abbreviation;
+                record.CountyName = allCounties.First(e => e.Id == cave.CountyId).Name;
                 record.AlternateNames = cave.AlternateNamesList;
                 record.CaveLengthFeet = cave.LengthFeet;
                 record.CaveDepthFeet = cave.DepthFeet;
                 record.MaxPitDepthFeet = cave.MaxPitDepthFeet;
                 record.NumberOfPits = cave.NumberOfPits;
-                record.Narrative = cave.Narrative;
                 record.ReportedOnDate = cave.ReportedOn;
                 record.IsArchived = cave.IsArchived;
                 record.Geology = cave.GeologyTags
@@ -712,13 +791,52 @@ public class ImportService : ServiceBase
                     .Select(e => allOtherTags.First(ee => ee.Id == e.TagTypeId).Name).ToList();
                 record.MapStatuses = cave.MapStatusTags
                     .Select(e => allMapStatusTags.First(ee => ee.Id == e.TagTypeId).Name).ToList();
+                record.Narrative = cave.Narrative;
 
                 records.Add(record);
+            }
+
+            if (syncExisting)
+            {
+                foreach (var caveId in caveIdsToDelete)
+                {
+                    var deletedCave = existingCaves.First(e => e.Id == caveId);
+                    records.Add(new CaveDryRunRecord
+                    {
+                        Action = "delete",
+                        ChangesSummary = null,
+                        State = deletedCave.StateAbbreviation,
+                        CountyName = deletedCave.CountyName,
+                        CountyCode = deletedCave.CountyDisplayId,
+                        CountyCaveNumber = deletedCave.CountyNumber,
+                        CaveName = deletedCave.Name
+                    });
+                }
+            }
+
+            if (syncExisting && caveIdsToDelete.Any())
+            {
+                await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Deleting caves missing from the CSV.");
+                foreach (var caveId in caveIdsToDelete)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await _caveService.DeleteCave(caveId, cancellationToken, transaction, deferredFileDeletes);
+                }
+
+                await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished deleting missing caves.");
             }
 
             if (!isDryRun)
             {
                 await transaction.CommitAsync(cancellationToken);
+
+                if (syncExisting)
+                {
+                    foreach (var file in deferredFileDeletes)
+                    {
+                        await _fileService.DeleteFile(file.BlobKey, file.BlobContainer);
+                    }
+                }
             }
             else
             {
@@ -842,7 +960,8 @@ public class ImportService : ServiceBase
     private bool IsValidCave(Cave cave, HashSet<UsedCountyNumber> usedCountyNumbers,
         CaveCsvModel currentRecord,
         int currentRowNumber,
-        List<FailedCaveCsvRecord<CaveCsvModel>> failedRecords)
+        List<FailedCaveCsvRecord<CaveCsvModel>> failedRecords,
+        bool skipCountyNumberConflictCheck = false)
     {
         var isValid = true;
         if (cave == null) throw ApiExceptionDictionary.BadRequest("Cave is null");
@@ -865,15 +984,18 @@ public class ImportService : ServiceBase
                 }
             }
 
-        if (usedCountyNumbers.Any(e => e.CountyId == cave.CountyId && e.CountyNumber == cave.CountyNumber))
+        if (!skipCountyNumberConflictCheck)
         {
-            failedRecords.Add(new FailedCaveCsvRecord<CaveCsvModel>(currentRecord, currentRowNumber,
-                $"County number is already used"));
-            isValid = false;
-        }
-        else
-        {
-            usedCountyNumbers.Add(new UsedCountyNumber(cave.CountyId, cave.CountyNumber));
+            if (usedCountyNumbers.Any(e => e.CountyId == cave.CountyId && e.CountyNumber == cave.CountyNumber))
+            {
+                failedRecords.Add(new FailedCaveCsvRecord<CaveCsvModel>(currentRecord, currentRowNumber,
+                    $"County number is already used"));
+                isValid = false;
+            }
+            else
+            {
+                usedCountyNumbers.Add(new UsedCountyNumber(cave.CountyId, cave.CountyNumber));
+            }
         }
 
         if (cave.CountyId == null)
@@ -914,6 +1036,150 @@ public class ImportService : ServiceBase
         return isValid;
     }
 
+    private static string? BuildCaveChangeSummary(
+        ImportSyncCaveLookup existingCave,
+        Cave importedCave,
+        IReadOnlyDictionary<string, string> geologyNames,
+        IReadOnlyDictionary<string, string> geologicAgeNames,
+        IReadOnlyDictionary<string, string> mapStatusNames,
+        IReadOnlyDictionary<string, string> physiographicProvinceNames,
+        IReadOnlyDictionary<string, string> archeologyNames,
+        IReadOnlyDictionary<string, string> biologyNames,
+        IReadOnlyDictionary<string, string> otherTagNames,
+        IReadOnlyDictionary<string, string> peopleNames)
+    {
+        var changes = new List<string>();
+
+        AddValueChange(changes, "Name", FormatText(existingCave.Name), FormatText(importedCave.Name));
+        AddValueChange(changes, "Alternate names", FormatText(existingCave.AlternateNames), FormatText(importedCave.AlternateNames));
+        AddValueChange(changes, "Length (ft)", FormatNumber(existingCave.LengthFeet), FormatNumber(importedCave.LengthFeet));
+        AddValueChange(changes, "Depth (ft)", FormatNumber(existingCave.DepthFeet), FormatNumber(importedCave.DepthFeet));
+        AddValueChange(changes, "Max pit depth (ft)", FormatNumber(existingCave.MaxPitDepthFeet), FormatNumber(importedCave.MaxPitDepthFeet));
+        AddValueChange(changes, "Number of pits", FormatInt(existingCave.NumberOfPits), FormatInt(importedCave.NumberOfPits));
+        AddNarrativeChange(changes, existingCave.Narrative, importedCave.Narrative);
+        AddValueChange(changes, "Reported on", FormatDate(existingCave.ReportedOn), FormatDate(importedCave.ReportedOn));
+        AddValueChange(changes, "Archived", FormatBool(existingCave.IsArchived), FormatBool(importedCave.IsArchived));
+
+        AddSetChange(changes, "Geology", existingCave.GeologyTagIds, importedCave.GeologyTags.Select(e => e.TagTypeId), geologyNames);
+        AddSetChange(changes, "Geologic ages", existingCave.GeologicAgeTagIds, importedCave.GeologicAgeTags.Select(e => e.TagTypeId), geologicAgeNames);
+        AddSetChange(changes, "Map statuses", existingCave.MapStatusTagIds, importedCave.MapStatusTags.Select(e => e.TagTypeId), mapStatusNames);
+        AddSetChange(changes, "Physiographic provinces", existingCave.PhysiographicProvinceTagIds, importedCave.PhysiographicProvinceTags.Select(e => e.TagTypeId), physiographicProvinceNames);
+        AddSetChange(changes, "Archeology", existingCave.ArcheologyTagIds, importedCave.ArcheologyTags.Select(e => e.TagTypeId), archeologyNames);
+        AddSetChange(changes, "Biology", existingCave.BiologyTagIds, importedCave.BiologyTags.Select(e => e.TagTypeId), biologyNames);
+        AddSetChange(changes, "Other tags", existingCave.OtherTagIds, importedCave.CaveOtherTags.Select(e => e.TagTypeId), otherTagNames);
+        AddSetChange(changes, "Cartographer names", existingCave.CartographerNameTagIds, importedCave.CartographerNameTags.Select(e => e.TagTypeId), peopleNames);
+        AddSetChange(changes, "Reported by names", existingCave.ReportedByNameTagIds, importedCave.CaveReportedByNameTags.Select(e => e.TagTypeId), peopleNames);
+
+        return changes.Any() ? string.Join(" | ", changes) : null;
+    }
+
+    private static bool SetEquals(IEnumerable<string> existingValues, IEnumerable<string> importedValues)
+    {
+        return existingValues.OrderBy(e => e).SequenceEqual(importedValues.OrderBy(e => e));
+    }
+
+    private static void AddValueChange(List<string> changes, string label, string existingValue, string importedValue)
+    {
+        if (existingValue == importedValue) return;
+        changes.Add($"{label} changed from {existingValue} to {importedValue}");
+    }
+
+    private static void AddNarrativeChange(List<string> changes, string? existingValue, string? importedValue)
+    {
+        var existingNarrative = NormalizeOptionalText(existingValue);
+        var importedNarrative = NormalizeOptionalText(importedValue);
+
+        if (existingNarrative == importedNarrative) return;
+
+        if (existingNarrative == null)
+        {
+            changes.Add($"Narrative added ({importedNarrative!.Length} chars)");
+            return;
+        }
+
+        if (importedNarrative == null)
+        {
+            changes.Add("Narrative removed");
+            return;
+        }
+
+        changes.Add(existingNarrative.Length == importedNarrative.Length
+            ? $"Narrative updated ({importedNarrative.Length} chars)"
+            : $"Narrative updated ({existingNarrative.Length} -> {importedNarrative.Length} chars)");
+    }
+
+    private static void AddSetChange(
+        List<string> changes,
+        string label,
+        IEnumerable<string> existingValues,
+        IEnumerable<string> importedValues,
+        IReadOnlyDictionary<string, string> nameLookup)
+    {
+        var existing = existingValues
+            .Select(e => nameLookup.GetValueOrDefault(e, e))
+            .Select(NormalizeOptionalText)
+            .Where(e => e != null)
+            .Distinct()
+            .OrderBy(e => e)
+            .ToList();
+        var imported = importedValues
+            .Select(e => nameLookup.GetValueOrDefault(e, e))
+            .Select(NormalizeOptionalText)
+            .Where(e => e != null)
+            .Distinct()
+            .OrderBy(e => e)
+            .ToList();
+
+        var added = imported.Except(existing).ToList();
+        var removed = existing.Except(imported).ToList();
+
+        if (added.Any())
+        {
+            changes.Add($"Added {label.ToLowerInvariant()}: {string.Join(", ", added)}");
+        }
+
+        if (removed.Any())
+        {
+            changes.Add($"Removed {label.ToLowerInvariant()}: {string.Join(", ", removed)}");
+        }
+    }
+
+    private static string FormatSet(IEnumerable<string> values)
+    {
+        var items = values.Where(e => !string.IsNullOrWhiteSpace(e)).OrderBy(e => e).ToList();
+        return items.Any() ? $"\"{string.Join(", ", items)}\"" : "blank";
+    }
+
+    private static string FormatText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "blank" : $"\"{value}\"";
+    }
+
+    private static string? NormalizeOptionalText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string FormatNumber(double? value)
+    {
+        return value?.ToString(CultureInfo.InvariantCulture) ?? "blank";
+    }
+
+    private static string FormatInt(int? value)
+    {
+        return value?.ToString(CultureInfo.InvariantCulture) ?? "blank";
+    }
+
+    private static string FormatDate(DateTime? value)
+    {
+        return value?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "blank";
+    }
+
+    private static string FormatBool(bool value)
+    {
+        return value ? "Yes" : "No";
+    }
+
     private async Task<List<TagType>> CreateAndProcessCaveTags(
         IEnumerable<CaveCsvModel> caveRecords,
         IEnumerable<TagType> existingTags,
@@ -938,9 +1204,9 @@ public class ImportService : ServiceBase
                 Id = IdGenerator.Generate(),
                 Name = e ?? throw ApiExceptionDictionary.NullValue(nameof(TagType.Name))
             })
-            .OrderBy(e=>e.Name)
+            .OrderBy(e => e.Name)
             .ToList();
-        
+
         // Determine new tags that don't already exist in the system
         var newTags = tags.Where(gt => allTags.All(ag => ag.Name != gt.Name)).ToList();
         foreach (var newTag in newTags)
@@ -973,6 +1239,7 @@ public class ImportService : ServiceBase
     #region Entrance Import
 
     public async Task<List<EntranceDryRun>> ImportEntrancesFileProcess(string temporaryFileId, bool isDryRun,
+        bool syncExisting,
         CancellationToken cancellationToken)
     {
         if (RequestUser.AccountId == null) throw ApiExceptionDictionary.NoAccount;
@@ -991,8 +1258,6 @@ public class ImportService : ServiceBase
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Started parsing CSV");
             var entranceRecords = await ParseEntranceCsv(stream, failedRecords, cancellationToken);
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Finished parsing CSV");
-
-            var entrances = new List<TemporaryEntrance>();
 
             #region Tags
 
@@ -1028,6 +1293,7 @@ public class ImportService : ServiceBase
 
             #endregion
 
+            var entrances = new List<TemporaryEntrance>();
             var rowNumber = 0;
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Started processing entrances");
             foreach (var entranceRecord in entranceRecords)
@@ -1036,7 +1302,6 @@ public class ImportService : ServiceBase
                 try
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-
                     #region Validation
 
                     var isValidReportedOn = DateTime.TryParse(entranceRecord.ReportedOnDate, out var reportedOnDate);
@@ -1107,10 +1372,7 @@ public class ImportService : ServiceBase
                             $"Missing value for {nameof(entranceRecord.CountyCode)}"));
                         continue;
                     }
-
                     #endregion
-
-
                     var entrance = new TemporaryEntrance()
                     {
                         Id = IdGenerator.Generate(),
@@ -1132,9 +1394,7 @@ public class ImportService : ServiceBase
 
                     entranceRecord.EntranceId =
                         entrance.Id; // used to associate with erroneous records after inserting into the db
-
                     #region Tags
-
                     CreateEntranceTags(
                         entranceRecord, entrance.Id,
                         nameof(entranceRecord.EntranceStatuses),
@@ -1162,7 +1422,6 @@ public class ImportService : ServiceBase
                         entranceReportedByNameTags,
                         e => e.ReportedByNames,
                         allPeopleTags);
-
                     #endregion
 
                     var isValid = IsValidEntrance(entrance, entranceRecord, rowNumber, failedRecords);
@@ -1202,7 +1461,6 @@ public class ImportService : ServiceBase
                 var unassociatedRecord = entranceRecords.FirstOrDefault(e => e.EntranceId == unassociatedEntranceId);
                 if (unassociatedRecord == null) continue;
 
-                // calculate row number from the index of the record in the list, +2 because the first row is the header and the index is 0 based
                 var calculatedRowNumber = entranceRecords.IndexOf(unassociatedRecord) + 2;
                 failedRecords.Add(new FailedCaveCsvRecord<EntranceCsvModel>(unassociatedRecord, calculatedRowNumber,
                     $"Entrance could not be associated with the cave {unassociatedRecord.CountyCode}-{unassociatedRecord.CountyCaveNumber}"));
@@ -1212,6 +1470,24 @@ public class ImportService : ServiceBase
             {
                 failedRecords = failedRecords.OrderBy(e => e.RowNumber).ToList();
                 throw ApiExceptionDictionary.InvalidImport(failedRecords, ImportType.Entrance);
+            }
+
+            var importedCaveIds = associatedEntrances
+                .Select(e => e.CaveId)
+                .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Cast<string>()
+                .Distinct()
+                .ToList();
+            var existingEntranceCounts = await _temporaryEntranceRepository.GetExistingEntranceCounts(importedCaveIds,
+                cancellationToken);
+            var importedEntranceCounts = associatedEntrances
+                .Where(e => !string.IsNullOrWhiteSpace(e.CaveId))
+                .GroupBy(e => e.CaveId!)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            if (syncExisting)
+            {
+                await _temporaryEntranceRepository.DeleteExistingEntrancesForImportedCaves(cancellationToken);
             }
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup,
@@ -1268,15 +1544,14 @@ public class ImportService : ServiceBase
                 batchSize: batchSize,
                 cancellationToken: cancellationToken);
 
-
             #endregion
 
             await _temporaryEntranceRepository.DropTable();
-            
+
             var records = new List<EntranceDryRun>();
 
             await _notificationService.SendNotificationToGroupAsync(signalRGroup, "Started processing result!");
-            
+
             var locationQualityDict = allLocationQualityTags.ToDictionary(e => e.Id, e => e.Name);
             var entranceStatusDict = entranceStatusTags
                 .GroupBy(e => e.EntranceId)
@@ -1307,10 +1582,20 @@ public class ImportService : ServiceBase
             foreach (var entrance in entrances)
             {
                 associatedEntrancesDict.TryGetValue(entrance.Id, out var associatedCave);
+                var existingEntranceCount = associatedCave?.CaveId != null
+                    ? existingEntranceCounts.GetValueOrDefault(associatedCave.CaveId)
+                    : 0;
+                var importedEntranceCount = associatedCave?.CaveId != null
+                    ? importedEntranceCounts.GetValueOrDefault(associatedCave.CaveId)
+                    : 0;
+                var finalEntranceCount = syncExisting
+                    ? importedEntranceCount
+                    : existingEntranceCount + importedEntranceCount;
 
                 var record = new EntranceDryRun
                 {
                     AssociatedCave = $"{associatedCave?.DisplayId} {associatedCave?.CaveName}",
+                    EntranceCountChange = finalEntranceCount - existingEntranceCount,
                     LocationQuality = locationQualityDict[entrance.LocationQualityTagId],
                     IsPrimaryEntrance = entrance.IsPrimary,
                     EntranceName = entrance.Name,
@@ -1336,12 +1621,11 @@ public class ImportService : ServiceBase
                 };
 
                 records.Add(record);
-                
+
                 if (records.Count % 100 == 0)
                 {
                     await _notificationService.SendNotificationToGroupAsync(signalRGroup, $"Processing preview of {records.Count} entrances out of {entrances.Count}");
                 }
-                
             }
 
             if (!isDryRun)
@@ -1581,7 +1865,7 @@ public class ImportService : ServiceBase
             FileName = fileName,
             IsSuccessful = true,
         };
-        
+
         CountyCaveInfo parsed;
         try
         {
@@ -1665,7 +1949,7 @@ public class ImportService : ServiceBase
                         $"'{input}' does not contain a valid county cave number.");
 
                 }
-                
+
                 countyCaveNumber = caveNumber;
                 countyCode = parts[0];
             }
@@ -1683,24 +1967,20 @@ public class ImportService : ServiceBase
 
 public class CaveDryRunRecord
 {
-    [MaxLength(PropertyLength.Id)] public string State { get; set; } = null!;
-    [MaxLength(PropertyLength.Id)] public string CountyName { get; set; } = null!;
-
     public string CountyCode { get; set; } = null!;
     public int CountyCaveNumber { get; set; }
-
     [MaxLength(PropertyLength.Name)] public string CaveName { get; set; } = null!;
+    public string? ChangesSummary { get; set; }
+    public string Action { get; set; } = null!;
+    [MaxLength(PropertyLength.Id)] public string State { get; set; } = null!;
+    [MaxLength(PropertyLength.Id)] public string CountyName { get; set; } = null!;
     public IEnumerable<string> AlternateNames { get; set; } = new List<string>();
 
     public double? CaveLengthFeet { get; set; }
     public double? CaveDepthFeet { get; set; }
     public double? MaxPitDepthFeet { get; set; }
     public int? NumberOfPits { get; set; } = 0;
-
-    public string? Narrative { get; set; }
-
     public DateTime? ReportedOnDate { get; set; }
-
     public bool IsArchived { get; set; } = false;
     public IEnumerable<string> Geology { get; set; } = new HashSet<string>();
     public IEnumerable<string> ReportedByNames { get; set; } = new HashSet<string>();
@@ -1711,11 +1991,13 @@ public class CaveDryRunRecord
     public IEnumerable<string> PhysiographicProvinces { get; set; } = new HashSet<string>();
     public IEnumerable<string> OtherTags { get; set; } = new HashSet<string>();
     public IEnumerable<string> MapStatuses { get; set; } = new HashSet<string>();
+    public string? Narrative { get; set; }
 }
 
 public class EntranceDryRun
 {
     public string AssociatedCave { get; set; }
+    public int EntranceCountChange { get; set; }
     [MaxLength(PropertyLength.Id)] public string LocationQuality { get; set; } = null!;
 
     public bool IsPrimaryEntrance { get; set; }

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -625,11 +625,15 @@ public class ImportService : ServiceBase
                             allBiologyTags.ToDictionary(e => e.Id, e => e.Name),
                             allOtherTags.ToDictionary(e => e.Id, e => e.Name),
                             allPeopleTags.ToDictionary(e => e.Id, e => e.Name));
-                        caveActionsById[cave.Id] = string.IsNullOrWhiteSpace(changeSummary)
+                        var action = string.IsNullOrWhiteSpace(changeSummary)
                             ? "no change"
                             : "update";
+                        caveActionsById[cave.Id] = action;
                         caveChangeSummariesById[cave.Id] = changeSummary;
-                        cavesForUpdate.Add(cave);
+                        if (action == "update")
+                        {
+                            cavesForUpdate.Add(cave);
+                        }
                     }
                     else if (syncExisting)
                     {
@@ -1492,23 +1496,57 @@ public class ImportService : ServiceBase
                 "Validating there is only one primary entrance per cave");
             var invalidPrimaryEntrance = await _temporaryEntranceRepository.GetInvalidIsPrimaryRecords();
             if (invalidPrimaryEntrance.Any())
+            {
+                var associatedEntrancesById = associatedEntrances.ToDictionary(e => e.Id);
+                var invalidCaveIds = new HashSet<string>();
                 foreach (var tempEntranceId in invalidPrimaryEntrance)
                 {
-                    var tempEntrance = entrances.FirstOrDefault(e => e.Id == tempEntranceId);
-                    if (tempEntrance == null)
+                    if (!associatedEntrancesById.TryGetValue(tempEntranceId, out var associatedEntrance) ||
+                        string.IsNullOrWhiteSpace(associatedEntrance.CaveId))
                         throw ApiExceptionDictionary.InternalServerError(
                             "There was an issue validating primary entrances.");
 
-                    var record = entranceRecords.FirstOrDefault(e => e.EntranceId == tempEntranceId);
+                    if (!invalidCaveIds.Add(associatedEntrance.CaveId))
+                    {
+                        continue;
+                    }
+
+                    var caveEntranceIds = associatedEntrances
+                        .Where(e => e.CaveId == associatedEntrance.CaveId)
+                        .Select(e => e.Id)
+                        .ToHashSet();
+                    var record = entranceRecords.FirstOrDefault(e => caveEntranceIds.Contains(e.EntranceId ?? ""));
                     if (record == null)
                         throw ApiExceptionDictionary.InternalServerError(
                             "There was an issue validating primary entrances.");
 
-                    // calculate row number from the index of the record in the list, +2 because the first row is the header and the index is 0 based
-                    var calculatedRowNumber = entranceRecords.IndexOf(record) + 2;
-                    failedRecords.Add(new FailedCaveCsvRecord<EntranceCsvModel>(record, calculatedRowNumber,
-                        $"Entrance is marked as primary but there is already a primary entrance for the cave {record.CountyCode}-{record.CountyCaveNumber}"));
+                    var existingPrimaryCount = syncExisting
+                        ? 0
+                        : existingEntranceCounts.GetValueOrDefault(associatedEntrance.CaveId);
+                    var importedPrimaryCount = associatedEntrances
+                        .Count(e => e.CaveId == associatedEntrance.CaveId &&
+                                    entrances.Any(entrance => entrance.Id == e.Id && entrance.IsPrimary));
+                    var finalPrimaryCount = existingPrimaryCount + importedPrimaryCount;
+                    if (finalPrimaryCount == 0)
+                    {
+                        var calculatedRowNumber = entranceRecords.IndexOf(record) + 2;
+                        failedRecords.Add(new FailedCaveCsvRecord<EntranceCsvModel>(record, calculatedRowNumber,
+                            $"No primary entrance found for cave {record.CountyCode}-{record.CountyCaveNumber}"));
+                        continue;
+                    }
+
+                    var offendingPrimaryRecords = entranceRecords
+                        .Where(e => caveEntranceIds.Contains(e.EntranceId ?? "") && e.IsPrimaryEntrance == true)
+                        .ToList();
+
+                    foreach (var offendingRecord in offendingPrimaryRecords)
+                    {
+                        var calculatedRowNumber = entranceRecords.IndexOf(offendingRecord) + 2;
+                        failedRecords.Add(new FailedCaveCsvRecord<EntranceCsvModel>(offendingRecord, calculatedRowNumber,
+                            $"Entrance is marked as primary but there is already a primary entrance for the cave {offendingRecord.CountyCode}-{offendingRecord.CountyCaveNumber}"));
+                    }
                 }
+            }
 
             if (failedRecords.Any())
             {

--- a/Planarian/Planarian/Modules/Account/Services/ImportService.cs
+++ b/Planarian/Planarian/Modules/Account/Services/ImportService.cs
@@ -1482,6 +1482,8 @@ public class ImportService : ServiceBase
                 .ToList();
             var existingEntranceCounts = await _temporaryEntranceRepository.GetExistingEntranceCounts(importedCaveIds,
                 cancellationToken);
+            var existingPrimaryEntranceCounts = await _temporaryEntranceRepository.GetExistingPrimaryEntranceCounts(
+                importedCaveIds, cancellationToken);
             var importedEntranceCounts = associatedEntrances
                 .Where(e => !string.IsNullOrWhiteSpace(e.CaveId))
                 .GroupBy(e => e.CaveId!)
@@ -1522,7 +1524,7 @@ public class ImportService : ServiceBase
 
                     var existingPrimaryCount = syncExisting
                         ? 0
-                        : existingEntranceCounts.GetValueOrDefault(associatedEntrance.CaveId);
+                        : existingPrimaryEntranceCounts.GetValueOrDefault(associatedEntrance.CaveId);
                     var importedPrimaryCount = associatedEntrances
                         .Count(e => e.CaveId == associatedEntrance.CaveId &&
                                     entrances.Any(entrance => entrance.Id == e.Id && entrance.IsPrimary));

--- a/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
+++ b/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
 using Planarian.Library.Exceptions;
 using Planarian.Library.Extensions.DateTime;
@@ -998,6 +999,7 @@ public class CaveRepository<TDbContext> : RepositoryBase<TDbContext> where TDbCo
             .Include(e => e.PhysiographicProvinceTags)
             .Include(e => e.CaveOtherTags)
             .Include(e => e.CaveReportedByNameTags)
+            .Include(e => e.Favorites)
             .Include(e => e.Files)
             .Include(e => e.CaveReportedByNameTags)
             .Include(e => e.Entrances)
@@ -1028,6 +1030,116 @@ public class CaveRepository<TDbContext> : RepositoryBase<TDbContext> where TDbCo
             .ToListAsync();
 
         return usedCountyNumbers.ToHashSet();
+    }
+
+    public async Task<List<ImportSyncCaveLookup>> GetImportSyncCaves()
+    {
+        return await DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => e.AccountId == RequestUser.AccountId)
+            .Select(e => new ImportSyncCaveLookup(
+                e.Id,
+                e.StateId,
+                e.State.Abbreviation,
+                e.CountyId,
+                e.County.Name,
+                e.County.DisplayId,
+                e.CountyNumber,
+                e.Name,
+                e.AlternateNames,
+                e.LengthFeet,
+                e.DepthFeet,
+                e.MaxPitDepthFeet,
+                e.NumberOfPits,
+                e.Narrative,
+                e.ReportedOn,
+                e.IsArchived,
+                e.GeologyTags.Select(tag => tag.TagTypeId),
+                e.GeologicAgeTags.Select(tag => tag.TagTypeId),
+                e.MapStatusTags.Select(tag => tag.TagTypeId),
+                e.PhysiographicProvinceTags.Select(tag => tag.TagTypeId),
+                e.ArcheologyTags.Select(tag => tag.TagTypeId),
+                e.BiologyTags.Select(tag => tag.TagTypeId),
+                e.CaveOtherTags.Select(tag => tag.TagTypeId),
+                e.CartographerNameTags.Select(tag => tag.TagTypeId),
+                e.CaveReportedByNameTags.Select(tag => tag.TagTypeId)))
+            .ToListAsync();
+    }
+
+    public async Task BulkUpdateImportCaves(List<Cave> caves, CancellationToken cancellationToken)
+    {
+        if (!caves.Any()) return;
+
+        var scopedCaveIds = await DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => caves.Select(ee => ee.Id).Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken);
+
+        var scopedCaves = caves.Where(e => scopedCaveIds.Contains(e.Id)).ToList();
+        if (!scopedCaves.Any()) return;
+
+        var config = new BulkConfig
+        {
+            PropertiesToInclude = new List<string>
+            {
+                nameof(Cave.Name),
+                nameof(Cave.AlternateNames),
+                nameof(Cave.CountyId),
+                nameof(Cave.CountyNumber),
+                nameof(Cave.StateId),
+                nameof(Cave.LengthFeet),
+                nameof(Cave.DepthFeet),
+                nameof(Cave.MaxPitDepthFeet),
+                nameof(Cave.NumberOfPits),
+                nameof(Cave.Narrative),
+                nameof(Cave.ReportedOn),
+                nameof(Cave.IsArchived)
+            }
+        };
+
+        await DbContext.BulkUpdateAsync(scopedCaves, config, cancellationToken: cancellationToken);
+    }
+
+    public async Task DeleteImportSyncCaveTags(List<string> caveIds, CancellationToken cancellationToken)
+    {
+        if (!caveIds.Any()) return;
+
+        var scopedCaveIds = await DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => caveIds.Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken);
+
+        if (!scopedCaveIds.Any()) return;
+
+        await DbContext.Set<GeologyTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<GeologicAgeTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<MapStatusTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<PhysiographicProvinceTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<ArcheologyTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<BiologyTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<CaveOtherTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<CartographerNameTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Set<CaveReportedByNameTag>()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .ExecuteDeleteAsync(cancellationToken);
     }
 
     public record GetCaveForFileImportByCountyCodeNumberResult(string CaveId, string CaveName);
@@ -1125,3 +1237,29 @@ public class CaveRepository : CaveRepository<PlanarianDbContext>
 }
 
 public record UsedCountyNumber(string CountyId, int CountyNumber);
+public record ImportSyncCaveLookup(
+    string Id,
+    string StateId,
+    string StateAbbreviation,
+    string CountyId,
+    string CountyName,
+    string CountyDisplayId,
+    int CountyNumber,
+    string Name,
+    string? AlternateNames,
+    double? LengthFeet,
+    double? DepthFeet,
+    double? MaxPitDepthFeet,
+    int? NumberOfPits,
+    string? Narrative,
+    DateTime? ReportedOn,
+    bool IsArchived,
+    IEnumerable<string> GeologyTagIds,
+    IEnumerable<string> GeologicAgeTagIds,
+    IEnumerable<string> MapStatusTagIds,
+    IEnumerable<string> PhysiographicProvinceTagIds,
+    IEnumerable<string> ArcheologyTagIds,
+    IEnumerable<string> BiologyTagIds,
+    IEnumerable<string> OtherTagIds,
+    IEnumerable<string> CartographerNameTagIds,
+    IEnumerable<string> ReportedByNameTagIds);

--- a/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
+++ b/Planarian/Planarian/Modules/Caves/Repositories/CaveRepository.cs
@@ -1142,6 +1142,62 @@ public class CaveRepository<TDbContext> : RepositoryBase<TDbContext> where TDbCo
             .ExecuteDeleteAsync(cancellationToken);
     }
 
+    public async Task DeleteImportSyncCave(string caveId,
+        List<Planarian.Model.Database.Entities.RidgeWalker.File> deferredFileDeletes,
+        CancellationToken cancellationToken)
+    {
+        var cave = await DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => e.Id == caveId && e.AccountId == RequestUser.AccountId)
+            .Include(e => e.Files)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (cave == null) throw ApiExceptionDictionary.NotFound(nameof(cave.Id));
+
+        var entranceIds = await DbContext.Entrances
+            .IgnoreQueryFilters()
+            .Where(e => e.CaveId == caveId)
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken);
+
+        await DbContext.CaveGeoJsons
+            .Where(e => e.CaveId == caveId)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (entranceIds.Any())
+        {
+            await DbContext.EntranceStatusTags
+                .Where(e => entranceIds.Contains(e.EntranceId))
+                .ExecuteDeleteAsync(cancellationToken);
+            await DbContext.EntranceHydrologyTags
+                .Where(e => entranceIds.Contains(e.EntranceId))
+                .ExecuteDeleteAsync(cancellationToken);
+            await DbContext.FieldIndicationTags
+                .Where(e => entranceIds.Contains(e.EntranceId))
+                .ExecuteDeleteAsync(cancellationToken);
+            await DbContext.EntranceReportedByNameTags
+                .Where(e => entranceIds.Contains(e.EntranceId))
+                .ExecuteDeleteAsync(cancellationToken);
+            await DbContext.EntranceOtherTag
+                .Where(e => entranceIds.Contains(e.EntranceId))
+                .ExecuteDeleteAsync(cancellationToken);
+            await DbContext.Entrances
+                .IgnoreQueryFilters()
+                .Where(e => entranceIds.Contains(e.Id))
+                .ExecuteDeleteAsync(cancellationToken);
+        }
+
+        await DeleteImportSyncCaveTags([caveId], cancellationToken);
+        await DbContext.Favorites
+            .Where(e => e.CaveId == caveId && e.AccountId == RequestUser.AccountId)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        deferredFileDeletes.AddRange(cave.Files);
+
+        DbContext.Caves.Remove(cave);
+        await DbContext.SaveChangesAsync(cancellationToken);
+    }
+
     public record GetCaveForFileImportByCountyCodeNumberResult(string CaveId, string CaveName);
 
     public async Task<GetCaveForFileImportByCountyCodeNumberResult?> GetCaveForFileImportByCountyCodeNumber(

--- a/Planarian/Planarian/Modules/Caves/Services/CaveService.cs
+++ b/Planarian/Planarian/Modules/Caves/Services/CaveService.cs
@@ -818,7 +818,7 @@ public class CaveService : ServiceBase<CaveRepository>
     }
 
     public async Task DeleteCave(string caveId, CancellationToken cancellationToken,
-        IDbContextTransaction? transaction = null)
+        IDbContextTransaction? transaction = null, List<File>? deferredFileDeletes = null)
     {
         var outsideTransaction = transaction != null;
         transaction ??= await Repository.BeginTransactionAsync(cancellationToken);
@@ -831,6 +831,15 @@ public class CaveService : ServiceBase<CaveRepository>
 
             if (entity == null) throw ApiExceptionDictionary.NotFound(nameof(entity.Id));
             await RequestUser.HasCavePermission(PermissionPolicyKey.Manager, caveId, entity.CountyId);
+
+            var geoJsons = await Repository.GetCaveGeoJsonsAsync(caveId);
+            foreach (var geoJson in geoJsons)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Repository.RemoveCaveGeoJson(geoJson);
+            }
+
+            await Repository.SaveChangesAsync(cancellationToken);
 
             foreach (var entrance in entity.Entrances)
             {
@@ -953,6 +962,14 @@ public class CaveService : ServiceBase<CaveRepository>
 
             await Repository.SaveChangesAsync(cancellationToken);
 
+            foreach (var favorite in entity.Favorites)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Repository.Delete(favorite);
+            }
+
+            await Repository.SaveChangesAsync(cancellationToken);
+
             files = entity.Files.ToList();
 
             Repository.Delete(entity);
@@ -977,7 +994,14 @@ public class CaveService : ServiceBase<CaveRepository>
 
         if (isSuccessful)
         {
-            foreach (var file in files) await _fileService.DeleteFile(file.BlobKey, file.BlobContainer);
+            if (deferredFileDeletes != null)
+            {
+                deferredFileDeletes.AddRange(files);
+            }
+            else
+            {
+                foreach (var file in files) await _fileService.DeleteFile(file.BlobKey, file.BlobContainer);
+            }
         }
     }
 

--- a/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
+++ b/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
@@ -81,7 +81,7 @@ public class TemporaryEntranceRepository : RepositoryBase<PlanarianDbContextBase
         var associatedEntrances = await db.GetTable<TemporaryEntrance>()
             .TableName(_temporaryEntranceTableName) 
             .Where(e => e.CaveId != null)
-            .Join(db.GetTable<Cave>(),
+            .Join(db.GetTable<Cave>().Where(e => e.AccountId == RequestUser.AccountId),
                 te => te.CaveId,
                 cave => cave.Id,
                 (te, cave) => new TemporaryEntranceResult
@@ -108,35 +108,74 @@ public class TemporaryEntranceRepository : RepositoryBase<PlanarianDbContextBase
         await using var db = DbContext.CreateLinqToDBConnection();
 
         var tempEntranceTable = db.GetTable<TemporaryEntrance>().TableName(_temporaryEntranceTableName);
+        var importedCaveIds = await tempEntranceTable
+            .Where(e => e.CaveId != null)
+            .Select(e => e.CaveId!)
+            .Distinct()
+            .ToListAsyncLinqToDB();
+
+        if (!importedCaveIds.Any()) return [];
+
+        var scopedImportedCaveIds = await db.GetTable<Cave>()
+            .Where(e => importedCaveIds.Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            .ToListAsyncLinqToDB();
+
+        if (!scopedImportedCaveIds.Any()) return [];
+
         var entranceTable = db.GetTable<Entrance>();
+        var tempPrimaryCounts = (await tempEntranceTable
+            .Where(e => e.CaveId != null && e.IsPrimary)
+            .GroupBy(e => e.CaveId!)
+            .Select(g => new { CaveId = g.Key, Count = g.Count() })
+            .ToListAsyncLinqToDB())
+            .ToDictionary(x => x.CaveId, x => x.Count);
 
-        var invalidTempEntrances = new List<string>();
-        int batchSize = 1000;
-        int offset = 0;
-    
-        while(true)  // Continue processing batches until the end of the table is reached
-        {
-            var batchQuery = (from temp in tempEntranceTable.Skip(offset).Take(batchSize).Where(e => e.IsPrimary)
-                where tempEntranceTable.Any(e => e.CaveId == temp.CaveId && e.IsPrimary && e.Id != temp.Id)
-                      || entranceTable.Any(e => e.CaveId == temp.CaveId && e.IsPrimary)
-                select temp.Id);
+        var existingPrimaryCounts = (await entranceTable
+            .Join(db.GetTable<Cave>().Where(e => e.AccountId == RequestUser.AccountId),
+                entrance => entrance.CaveId,
+                cave => cave.Id,
+                (entrance, cave) => entrance)
+            .Where(e => scopedImportedCaveIds.Contains(e.CaveId) && e.IsPrimary)
+            .GroupBy(e => e.CaveId)
+            .Select(g => new { CaveId = g.Key, Count = g.Count() })
+            .ToListAsyncLinqToDB())
+            .ToDictionary(x => x.CaveId, x => x.Count);
 
-            var batchResult = await batchQuery.ToListAsyncLinqToDB();
-            invalidTempEntrances.AddRange(batchResult);
+        var invalidCaveIds = scopedImportedCaveIds
+            .Where(caveId =>
+                tempPrimaryCounts.GetValueOrDefault(caveId) + existingPrimaryCounts.GetValueOrDefault(caveId) != 1)
+            .ToList();
 
-            if(batchResult.Count < batchSize)
-            {
-                break;  // Exit loop if the end of the table is reached
-            }
+        if (!invalidCaveIds.Any()) return [];
 
-            offset += batchSize;  // Prepare to process the next batch
-        }
-
-        return invalidTempEntrances;
+        return await tempEntranceTable
+            .Where(e => e.CaveId != null && invalidCaveIds.Contains(e.CaveId))
+            .Select(e => e.Id)
+            .ToListAsyncLinqToDB();
     }
 
+    public async Task<Dictionary<string, int>> GetExistingEntranceCounts(IEnumerable<string> caveIds,
+        CancellationToken cancellationToken)
+    {
+        var caveIdList = caveIds.Distinct().ToList();
+        if (!caveIdList.Any()) return [];
 
+        var scopedCaveIds = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => caveIdList.Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            , cancellationToken);
 
+        if (!scopedCaveIds.Any()) return [];
+
+        return (await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(DbContext.Entrances
+            .IgnoreQueryFilters()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .GroupBy(e => e.CaveId)
+            .Select(g => new { CaveId = g.Key, Count = g.Count() }), cancellationToken))
+            .ToDictionary(x => x.CaveId, x => x.Count);
+    }
 
     public async Task MigrateTemporaryEntrancesAsync()
     {
@@ -185,6 +224,63 @@ public class TemporaryEntranceRepository : RepositoryBase<PlanarianDbContextBase
     {
         return DbContext.CreateLinqToDBConnection().GetTable<TemporaryEntrance>().TableName(_temporaryEntranceTableName)
             .Where(e => e.Id == id).ToList();
+    }
+
+    public async Task<List<TemporaryEntrance>> GetAllEntrances()
+    {
+        return await DbContext.CreateLinqToDBConnection()
+            .GetTable<TemporaryEntrance>()
+            .TableName(_temporaryEntranceTableName)
+            .ToListAsyncLinqToDB();
+    }
+
+    public async Task DeleteExistingEntrancesForImportedCaves(CancellationToken cancellationToken)
+    {
+        var caveIds = await DbContext.CreateLinqToDBConnection()
+            .GetTable<TemporaryEntrance>()
+            .TableName(_temporaryEntranceTableName)
+            .Where(e => e.CaveId != null)
+            .Select(e => e.CaveId!)
+            .Distinct()
+            .ToListAsyncLinqToDB();
+
+        if (!caveIds.Any()) return;
+
+        var scopedCaveIds = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => caveIds.Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            , cancellationToken);
+
+        if (!scopedCaveIds.Any()) return;
+
+        var entranceIds = await DbContext.Entrances
+            .IgnoreQueryFilters()
+            .Where(e => scopedCaveIds.Contains(e.CaveId))
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken: cancellationToken);
+
+        if (!entranceIds.Any()) return;
+
+        await DbContext.EntranceStatusTags
+            .Where(e => entranceIds.Contains(e.EntranceId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.EntranceHydrologyTags
+            .Where(e => entranceIds.Contains(e.EntranceId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.FieldIndicationTags
+            .Where(e => entranceIds.Contains(e.EntranceId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.EntranceReportedByNameTags
+            .Where(e => entranceIds.Contains(e.EntranceId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.EntranceOtherTag
+            .Where(e => entranceIds.Contains(e.EntranceId))
+            .ExecuteDeleteAsync(cancellationToken);
+        await DbContext.Entrances
+            .IgnoreQueryFilters()
+            .Where(e => entranceIds.Contains(e.Id))
+            .ExecuteDeleteAsync(cancellationToken);
     }
 
     public async Task DropTable()

--- a/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
+++ b/Planarian/Planarian/Modules/Import/Repositories/TemporaryEntranceRepository.cs
@@ -177,6 +177,28 @@ public class TemporaryEntranceRepository : RepositoryBase<PlanarianDbContextBase
             .ToDictionary(x => x.CaveId, x => x.Count);
     }
 
+    public async Task<Dictionary<string, int>> GetExistingPrimaryEntranceCounts(IEnumerable<string> caveIds,
+        CancellationToken cancellationToken)
+    {
+        var caveIdList = caveIds.Distinct().ToList();
+        if (!caveIdList.Any()) return [];
+
+        var scopedCaveIds = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(DbContext.Caves
+            .IgnoreQueryFilters()
+            .Where(e => caveIdList.Contains(e.Id) && e.AccountId == RequestUser.AccountId)
+            .Select(e => e.Id)
+            , cancellationToken);
+
+        if (!scopedCaveIds.Any()) return [];
+
+        return (await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(DbContext.Entrances
+            .IgnoreQueryFilters()
+            .Where(e => scopedCaveIds.Contains(e.CaveId) && e.IsPrimary)
+            .GroupBy(e => e.CaveId)
+            .Select(g => new { CaveId = g.Key, Count = g.Count() }), cancellationToken))
+            .ToDictionary(x => x.CaveId, x => x.Count);
+    }
+
     public async Task MigrateTemporaryEntrancesAsync()
     {
         var command = $@"


### PR DESCRIPTION
- update mode on import that will overwrite data on existing caves, while leaving favorites, files, line-plots, etc unchanged (unless the action is deleting a cave record because it is missing from the CSV)
- entrances get an insert mode that will only insert the entrances in the file
- update mode deletes the entrances for the caves in the file and replaces them with whatever is in the file