### PR TITLE
Safari Display Attributes Bug

### DIFF
--- a/Planarian.Web/src/Modules/Caves/Components/CavesComponent.scss
+++ b/Planarian.Web/src/Modules/Caves/Components/CavesComponent.scss
@@ -40,6 +40,12 @@
   width: 100%;
 }
 
+.caves-component__results > .feature-checkbox-group,
+.caves-component__results > .feature-checkbox-group--compact {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
 .caves-mobile-toolbar-row {
   align-items: center;
   display: flex;


### PR DESCRIPTION
fixed display attribute bug on desktop safari that clipped the content